### PR TITLE
RTMP Connect 수행

### DIFF
--- a/mediaServer/core/rtmp/connect.ts
+++ b/mediaServer/core/rtmp/connect.ts
@@ -1,0 +1,49 @@
+import net from 'net';
+import { encodeAmf0Cmd } from 'node-amfutils';
+
+const RESULT_COMMAND_MESSAGE = {
+  cmd: '_result',
+  transId: 1,
+  cmdObj: {
+    fmsVer: 'FMS/3,0,1,123',
+    capabilities: 31,
+  },
+  info: {
+    level: 'status',
+    code: 'NetConnection.Connect.Success',
+    description: 'Connection succeeded.',
+    objectEncoding: 0,
+  },
+};
+
+function writePacket(socket: net.Socket, streamId: number, messageTypeId: number, payload: Buffer) {
+  const basicHeader = Buffer.alloc(1);
+  basicHeader.writeIntLE(streamId, 0, 1);
+  const messageHeader = Buffer.alloc(11);
+  messageHeader.writeIntBE(payload.length, 3, 3); // message length 설정
+  messageHeader.writeIntBE(messageTypeId, 6, 1); // message type id 설정
+
+  socket.write(Buffer.concat([basicHeader, messageHeader, payload]));
+}
+
+function connect(socket: net.Socket) {
+  const windowAckSizePayload = Buffer.alloc(4);
+  windowAckSizePayload.writeIntBE(5000000, 0, 4);
+  writePacket(socket, 2, 5, windowAckSizePayload);
+
+  const setPeerBandwidthPayload = Buffer.alloc(5);
+  setPeerBandwidthPayload.writeIntBE(5000000, 0, 4);
+  setPeerBandwidthPayload.writeIntBE(2, 4, 1);
+  writePacket(socket, 2, 6, setPeerBandwidthPayload);
+
+  const setChunkSizePayload = Buffer.alloc(4);
+  setChunkSizePayload.writeIntBE(4096, 0, 4);
+  writePacket(socket, 2, 1, setChunkSizePayload);
+
+  const responsePayload = encodeAmf0Cmd(RESULT_COMMAND_MESSAGE);
+  writePacket(socket, 3, 20, responsePayload);
+
+  return true;
+}
+
+export { connect };

--- a/mediaServer/core/rtmp/packet.ts
+++ b/mediaServer/core/rtmp/packet.ts
@@ -109,7 +109,6 @@ function separateRtmpChunk(data: Buffer): RtmpChunck[] {
         } else if (chunk.basicHeader.chunkType === 3) {
           continue;
         }
-        console.log(offset, messageHeaderBytes);
         chunk.messageHeader = parseMessageHeader(
           chunk.basicHeader.chunkType,
           data.subarray(offset, offset + messageHeaderBytes),
@@ -137,4 +136,4 @@ function separateRtmpChunk(data: Buffer): RtmpChunck[] {
   return rtmpChunks;
 }
 
-export { separateRtmpChunk };
+export { separateRtmpChunk, RtmpChunck };

--- a/mediaServer/core/rtmp/packet.ts
+++ b/mediaServer/core/rtmp/packet.ts
@@ -1,0 +1,140 @@
+type RtmpChunckBasicHeader = {
+  chunkType: number;
+  chunkStreamId: number;
+};
+
+type RtmpChunckMessageHeader = {
+  timestamp: number;
+  messageLength: number;
+  typeId: number;
+  messageStreamId: number;
+};
+
+interface RtmpChunck {
+  basicHeader: RtmpChunckBasicHeader;
+  messageHeader: RtmpChunckMessageHeader;
+  extendedTimestamp: number;
+  payload: Buffer;
+}
+
+function createRtmpChunk(): RtmpChunck {
+  return {
+    basicHeader: {
+      chunkType: 0,
+      chunkStreamId: 0,
+    },
+    messageHeader: {
+      timestamp: 0,
+      messageLength: 0,
+      typeId: 0,
+      messageStreamId: 0,
+    },
+    extendedTimestamp: 0,
+    payload: Buffer.alloc(0),
+  };
+}
+
+function parseBasicHeader(data: Buffer): RtmpChunckBasicHeader {
+  let defaultBasicHeader = data.subarray(0, 1);
+  let chunkType = defaultBasicHeader[0] >> 6;
+  let chunkStreamId = defaultBasicHeader[0] & 0b00111111;
+
+  switch (chunkStreamId) {
+    case 0:
+      chunkStreamId = data.subarray(1, 2)[0] + 64;
+      break;
+    case 1:
+      const basicHeaderBytes1 = data.subarray(1, 2)[0];
+      const basicHeaderBytes2 = data.subarray(2, 3)[0];
+      chunkStreamId = basicHeaderBytes2 * 256 + basicHeaderBytes1 + 64;
+      break;
+    default:
+      break;
+  }
+  return { chunkType, chunkStreamId };
+}
+
+function parseMessageHeader(chunkType: number, data: Buffer): RtmpChunckMessageHeader {
+  let timestamp, messageLength, typeId, messageStreamId;
+
+  if (chunkType <= 2) {
+    timestamp = data.readIntBE(0, 3);
+  }
+  if (chunkType <= 1) {
+    messageLength = data.readIntBE(3, 3);
+    typeId = data.readIntBE(6, 1);
+  }
+  if (chunkType <= 0) {
+    messageStreamId = data.subarray(7).readInt32BE();
+  }
+
+  return { timestamp, messageLength, typeId, messageStreamId };
+}
+
+function separateRtmpChunk(data: Buffer): RtmpChunck[] {
+  const rtmpChunks: RtmpChunck[] = [];
+  const BASIC_HEADER_STATE = 0;
+  const MESSAGE_HEADER_STATE = 1;
+  const EXTENDED_TIMESTAMP_STATE = 2;
+  const PAYLOAD_STATE = 3;
+
+  let offset = 0;
+  let currentChunkState = 0;
+  let chunk: RtmpChunck = createRtmpChunk();
+
+  while (offset < data.length) {
+    switch (currentChunkState % 4) {
+      case BASIC_HEADER_STATE:
+        let basicHeaderBytes = 1;
+        chunk = createRtmpChunk();
+        const basicHeaderBuf = data.subarray(offset, offset + 1)[0];
+        const chunkStreamId = basicHeaderBuf & 0x3f;
+        if (chunkStreamId === 0) {
+          basicHeaderBytes = 2;
+        } else if (chunkStreamId === 1) {
+          basicHeaderBytes = 3;
+        }
+        chunk.basicHeader = parseBasicHeader(data.subarray(offset, offset + basicHeaderBytes));
+        offset += basicHeaderBytes;
+        currentChunkState += 1;
+        break;
+      case MESSAGE_HEADER_STATE:
+        let messageHeaderBytes = 0;
+        if (chunk.basicHeader.chunkType === 0) {
+          messageHeaderBytes = 11;
+        } else if (chunk.basicHeader.chunkType === 1) {
+          messageHeaderBytes = 7;
+        } else if (chunk.basicHeader.chunkType === 2) {
+          messageHeaderBytes = 3;
+        } else if (chunk.basicHeader.chunkType === 3) {
+          continue;
+        }
+        console.log(offset, messageHeaderBytes);
+        chunk.messageHeader = parseMessageHeader(
+          chunk.basicHeader.chunkType,
+          data.subarray(offset, offset + messageHeaderBytes),
+        );
+        offset += messageHeaderBytes;
+        currentChunkState += 1;
+        break;
+      case EXTENDED_TIMESTAMP_STATE:
+        const EXTENDED_TIMESTAMP_FLAG = chunk.messageHeader.timestamp === 16777215;
+        if (EXTENDED_TIMESTAMP_FLAG) {
+          chunk.messageHeader.timestamp = data.subarray(offset, offset + 4)[0];
+          offset += 4;
+        }
+        currentChunkState += 1;
+        break;
+      case PAYLOAD_STATE:
+        const messageLength = chunk.messageHeader.messageLength;
+        chunk.payload = data.subarray(offset, offset + messageLength);
+        offset += messageLength;
+        currentChunkState += 1;
+        rtmpChunks.push(chunk);
+        break;
+    }
+  }
+  return rtmpChunks;
+}
+
+export { separateRtmpChunk };

--- a/mediaServer/core/rtmp/stream.ts
+++ b/mediaServer/core/rtmp/stream.ts
@@ -1,0 +1,66 @@
+import net from 'net';
+import crypto from 'crypto';
+import { encodeAmf0Cmd, decodeAmf0Cmd } from 'node-amfutils';
+import { handshake, HandshakeData } from '@core/rtmp/handshake';
+import { separateRtmpChunk } from '@core/rtmp/packet';
+
+class RTMPStream {
+  handshakeData: HandshakeData;
+  isHandshakeDone: boolean;
+  isConnectDone: boolean;
+  isCreateStreamDone: boolean;
+  isPublishDone: boolean;
+
+  constructor(private socket: net.Socket) {
+    this.handshakeData = {
+      C0: Buffer.alloc(0),
+      C1: Buffer.alloc(0),
+      C2: Buffer.alloc(0),
+      C1_TIMESTAMP: Buffer.alloc(0),
+      C1_RANDOM_BYTES: Buffer.alloc(0),
+      S1_TIMESTAMP: Buffer.alloc(4),
+      S1_RANDOM_BYTES: crypto.randomBytes(1528),
+    };
+
+    this.isHandshakeDone = false;
+    this.isConnectDone = false;
+    this.isCreateStreamDone = false;
+    this.isPublishDone = false;
+  }
+
+  run() {
+    this.socket.on('data', this.dataEvent.bind(this));
+    this.socket.on('close', this.closeEvent.bind(this));
+    this.socket.on('error', this.errorEvent.bind(this));
+    this.socket.on('timeout', this.timeoutEvent.bind(this));
+  }
+
+  dataEvent(data) {
+    console.log(data.length);
+    if (!this.isHandshakeDone) {
+      this.isHandshakeDone = handshake(this.socket, data, this.handshakeData);
+    } else if (!this.isConnectDone) {
+      //
+    } else if (!this.isCreateStreamDone) {
+      //
+    } else if (!this.isPublishDone) {
+      //
+    } else {
+      //
+    }
+  }
+
+  closeEvent() {
+    this.socket.destroy();
+  }
+
+  errorEvent(error) {
+    this.socket.destroy();
+  }
+
+  timeoutEvent() {
+    this.socket.destroy();
+  }
+}
+
+export default RTMPStream;

--- a/mediaServer/core/rtmp/utils.ts
+++ b/mediaServer/core/rtmp/utils.ts
@@ -1,0 +1,11 @@
+import { decodeAmf0Cmd, decodeAmf3Cmd } from 'node-amfutils';
+
+function decodeAMF(typeId: number, paylod: Buffer, amf0Num: number, amf3Num: number) {
+  if (typeId === amf0Num) {
+    return decodeAmf0Cmd(paylod);
+  } else if (typeId === amf3Num) {
+    return decodeAmf3Cmd(paylod);
+  }
+}
+
+export { decodeAMF };

--- a/mediaServer/main.ts
+++ b/mediaServer/main.ts
@@ -1,23 +1,9 @@
 import net from 'net';
-import crypto from 'crypto';
-import { handshake, HandshakeData } from '@core/rtmp/handshake';
+import RTMPStream from '@core/rtmp/stream';
 
 const server = net.createServer((socket) => {
-  const handshakeData: HandshakeData = {
-    C0: Buffer.alloc(0),
-    C1: Buffer.alloc(0),
-    C2: Buffer.alloc(0),
-    C1_TIMESTAMP: Buffer.alloc(0),
-    C1_RANDOM_BYTES: Buffer.alloc(0),
-    S1_TIMESTAMP: Buffer.alloc(4),
-    S1_RANDOM_BYTES: crypto.randomBytes(1528),
-  };
-
-  socket.on('data', (data) => {
-    handshake(socket, data, handshakeData);
-  });
-
-  socket.on('error', (_) => socket.end());
+  const rtmpStream = new RTMPStream(socket);
+  rtmpStream.run();
 });
 
 const PORT = 3000;

--- a/mediaServer/package-lock.json
+++ b/mediaServer/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "net": "^1.0.2"
+        "net": "^1.0.2",
+        "node-amfutils": "^0.0.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -4020,6 +4021,12 @@
       "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
       "integrity": "sha512-kbhcj2SVVR4caaVnGLJKmlk2+f+oLkjqdKeQlmUtz6nGzOpbcobwVIeSURNgraV/v3tlmGIX82OcPCl0K6RbHQ==",
       "license": "MIT"
+    },
+    "node_modules/node-amfutils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-amfutils/-/node-amfutils-0.0.1.tgz",
+      "integrity": "sha512-RtqIo9i504IFapmmhPwA2LmdGl//jSK9qVtchU0MecIeRWAulKBATNpf3b0ypuZOC6rOPLyS+YFCkdZSt5fWRQ==",
+      "license": "GPLv2"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/mediaServer/package.json
+++ b/mediaServer/package.json
@@ -4,7 +4,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "net": "^1.0.2"
+    "net": "^1.0.2",
+    "node-amfutils": "^0.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/mediaServer/test/core/rtmp.test.ts
+++ b/mediaServer/test/core/rtmp.test.ts
@@ -1,5 +1,0 @@
-describe('sum module', () => {
-  test('adds 1 + 2 to equal 3', () => {
-    expect(1 + 2).toBe(3);
-  });
-});

--- a/mediaServer/tsconfig.json
+++ b/mediaServer/tsconfig.json
@@ -9,6 +9,7 @@
     "baseUrl": "./",
     "paths": {
       "@core/*": ["core/*"]
-    }
+    },
+    "noImplicitAny": false
   }
 }


### PR DESCRIPTION
## Issue

- [x] #2 


<br><br>

## Detail

* AMF 형식을 결정하여 페이로드 디코딩
  * 메시지 헤더의 typeId에 따라 AMF0/AMF3 형식을 결정하고 이에 맞게 페이로드를 디코딩하였다.
* Client로부터 오는 요청을 패킷 단위로 분리하여 객체로 생성
  * 하나의 패킷에 여러 `chunk`가 올 경우를 생각하여 패킷을 `chunk` 단위로 분리하여 `chunk` 배열로 반환하도록 처리하였다.
  * chunk` 단위 분리 로직은 [공식 문서](https://rtmp.veriskope.com/docs/spec/#531chunk-format)를 참고하여 형식에 맞게 분리하는 함수를 각각 작성하였다.
* RTMP Connect 과정을 모듈로 분리
  * `Window Acknowledgement Size` 제어 메시지 전송
  * `Set Peer Bandwidth` 제어 메시지 전송
  * `Set Chunk Size` 제어 메시지 전송
  * Result Command Response 메시지 전송
