### PR TITLE
feat: 서랍 상단 UI 구현

### DIFF
--- a/client/src/app/categories/page.tsx
+++ b/client/src/app/categories/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 const CategoriesPage = () => {
   return (
     <div>
-      <CategoryCard>hello world</CategoryCard>
+      <CategoryCard></CategoryCard>
     </div>
   );
 };

--- a/client/src/app/components/cabinet/Cabinet.tsx
+++ b/client/src/app/components/cabinet/Cabinet.tsx
@@ -1,0 +1,12 @@
+import clsx from 'clsx';
+import CabinetContainer from './CabinetContainer';
+
+const Cabinet = () => {
+  return (
+    <section className="funch-desktop:w-60 fixed left-0 top-0 h-full w-28 overflow-auto">
+      <CabinetContainer />
+    </section>
+  );
+};
+
+export default Cabinet;

--- a/client/src/app/components/cabinet/CabinetContainer.tsx
+++ b/client/src/app/components/cabinet/CabinetContainer.tsx
@@ -1,0 +1,31 @@
+import CabinetLink from './CabinetLink';
+import CategoryLink from './CategoryLink';
+import FollowLink from './FollowLink';
+
+const CabinetContainer = () => {
+  return (
+    <div className="flex h-full flex-col pt-16">
+      <CategoryNavigator />
+      <StreamerNavigator />
+    </div>
+  );
+};
+
+const CategoryNavigator = () => {
+  return (
+    <div className="funch-desktop:h-44 h-48 overflow-hidden">
+      <CabinetLink link="category" />
+      <CabinetLink link="follow" />
+    </div>
+  );
+};
+
+const StreamerNavigator = () => {
+  return (
+    <div className="funch-desktop:w-3/4 border-t-bg-strong mx-auto h-full w-1/2 overflow-y-auto border-t">
+      <h2></h2>
+    </div>
+  );
+};
+
+export default CabinetContainer;

--- a/client/src/app/components/cabinet/CabinetLink.tsx
+++ b/client/src/app/components/cabinet/CabinetLink.tsx
@@ -1,0 +1,37 @@
+import CategorySvg from '@components/svgs/CategorySvg';
+import FollowSvg from '@components/svgs/FollowSvg';
+import Link from 'next/link';
+
+type LinkProps = {
+  link: 'category' | 'follow';
+};
+
+const CabinetLink = ({ link }: LinkProps) => {
+  return link === 'category' ? (
+    <Link
+      href="/categories"
+      className="funch-desktop:flex hover:bg-border-neutral-weak funch-desktop:pl-[18px] funch-desktop:h-14 mx-auto mt-4 block h-16 w-4/5 items-center rounded-md"
+    >
+      <div className="funch-desktop:mx-0 mx-auto flex w-12 justify-center">
+        <CategorySvg />
+      </div>
+      <span className="funch-desktop:mt-0 funch-desktop:h-9 funch-desktop:flex funch-desktop:items-center funch-desktop:funch-bold16 funch-desktop:px-2 funch-medium14 mt-1 block text-center">
+        카테고리
+      </span>
+    </Link>
+  ) : (
+    <Link
+      href="/following"
+      className="funch-desktop:flex hover:bg-border-neutral-weak funch-desktop:pl-[18px] mx-auto mt-2 block h-14 w-4/5 items-center rounded-md"
+    >
+      <div className="funch-desktop:mx-0 mx-auto flex w-12 justify-center">
+        <FollowSvg />
+      </div>
+      <span className="funch-desktop:mt-0 funch-desktop:h-9 funch-desktop:flex funch-desktop:items-center funch-desktop:funch-bold16 funch-desktop:px-2 funch-medium14 mt-1 block text-center">
+        팔로잉
+      </span>
+    </Link>
+  );
+};
+
+export default CabinetLink;

--- a/client/src/app/components/cabinet/CategoryLink.tsx
+++ b/client/src/app/components/cabinet/CategoryLink.tsx
@@ -1,0 +1,20 @@
+import CategorySvg from '@components/svgs/CategorySvg';
+import Link from 'next/link';
+
+const CategoryLink = () => {
+  return (
+    <Link
+      href="/categories"
+      className="funch-desktop:flex hover:bg-border-neutral-weak funch-desktop:pl-[18px] mx-auto mt-4 block h-16 w-4/5 items-center rounded-md"
+    >
+      <div className="funch-desktop:mx-0 mx-auto flex w-12 justify-center">
+        <CategorySvg />
+      </div>
+      <span className="funch-desktop:mt-0 funch-desktop:h-9 funch-desktop:flex funch-desktop:items-center funch-desktop:funch-bold16 funch-desktop:px-2 funch-medium14 mt-1 block text-center">
+        카테고리
+      </span>
+    </Link>
+  );
+};
+
+export default CategoryLink;

--- a/client/src/app/components/cabinet/FollowLink.tsx
+++ b/client/src/app/components/cabinet/FollowLink.tsx
@@ -1,0 +1,20 @@
+import FollowSvg from '@components/svgs/FollowSvg';
+import Link from 'next/link';
+
+const FollowLink = () => {
+  return (
+    <Link
+      href="/categories"
+      className="funch-desktop:flex hover:bg-border-neutral-weak funch-desktop:pl-[18px] mx-auto mt-2 block h-14 w-4/5 items-center rounded-md"
+    >
+      <div className="funch-desktop:mx-0 mx-auto flex w-12 justify-center">
+        <FollowSvg />
+      </div>
+      <span className="funch-desktop:mt-0 funch-desktop:h-9 funch-desktop:flex funch-desktop:items-center funch-desktop:funch-bold16 funch-desktop:px-2 funch-medium14 mt-1 block text-center">
+        팔로잉
+      </span>
+    </Link>
+  );
+};
+
+export default FollowLink;

--- a/client/src/app/components/cabinet/StreamerLink.tsx
+++ b/client/src/app/components/cabinet/StreamerLink.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+type StreamerProps = {
+  id: string;
+  name: string;
+  logo: string;
+};
+
+const StreamerLink = ({ streamer }: { streamer: StreamerProps }) => {
+  const { id, name, logo } = streamer;
+  return (
+    <>
+      <Link href={`/streamer/${id}`} className="streamer-link">
+        <img src={logo} alt={name} />
+        <span>{name}</span>
+      </Link>
+    </>
+  );
+};
+
+export default StreamerLink;

--- a/client/src/app/components/svgs/CategorySvg.tsx
+++ b/client/src/app/components/svgs/CategorySvg.tsx
@@ -6,8 +6,8 @@ const CategorySvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
       role="img"
       focusable={false}
       aria-hidden={true}
-      width="26"
-      height="26"
+      width="35"
+      height="35"
       viewBox="0 0 26 26"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/client/src/app/components/svgs/FollowSvg.tsx
+++ b/client/src/app/components/svgs/FollowSvg.tsx
@@ -8,7 +8,7 @@ const FollowSvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
       <path
         stroke="currentColor"
         strokeLinejoin="round"
-        strokeWidth="1.5"
+        strokeWidth="2"
         d="M13.027 7.725C11.536 3.835 4 4.413 4 10.295c0 2.764 2.041 6.39 7.898 10.126.133.085.585.327 1.102.329.517.002.94-.226 1.055-.3C19.948 16.704 22 13.067 22 10.296c0-5.848-7.473-6.483-8.973-2.57Z"
       />
     </svg>

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import MswInitializer from './MswInitializer';
 import Header from './components/layout/Header';
 import GlobalProvider from './GlobalProvider';
+import Cabinet from '@components/cabinet/Cabinet';
 
 const notoSansKR = Noto_Sans_KR({
   weight: ['300', '500', '700'],
@@ -34,6 +35,7 @@ const RootLayout = ({
           <MswInitializer>
             <GlobalProvider>
               <Header />
+              <Cabinet />
               {/* {!wideView && <Cabinet />} */}
               <div>{children}</div>
             </GlobalProvider>

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -8,11 +8,7 @@ import ClientComponentForTest from '@components/ClientComponentForTest';
 
 const HomePage = () => {
   return (
-    <>
-      <h1>
-        <span>FUNCH</span>
-        <Ping />
-      </h1>
+    <div className="funch-desktop:pl-60 pl-28">
       <div>
         <p className="funch-bold24">helloworld</p>
         <p className="funch-bold16 text-content-brand-base">helloworld</p>
@@ -32,7 +28,7 @@ const HomePage = () => {
         <Badge category="발로란트" />
         <ClientComponentForTest />
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Issue

- [x] #30 


<br><br>

## Detail
- 서랍은 categoryNavigator, streamerNavigator로 나뉘어 있음
- CabinetLink를 props에 따라 다른 라우트, 아이콘을 보이게 함