### PR TITLE
refactor: HeaderControlButton, Image(for test), brand 색상, useInternalRouter

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: [
+      'via.placeholder.com', // sample domain for test
+    ],
+  },
+};
 
 export default nextConfig;

--- a/client/src/app/components/layout/Header.tsx
+++ b/client/src/app/components/layout/Header.tsx
@@ -3,7 +3,7 @@ import Search from './Search';
 
 const Header = () => {
   return (
-    <header className="h-header min-w-layout fixed left-0 top-0 z-50 w-full">
+    <header className="h-header min-w-layout fixed left-0 top-0 z-[9999] w-full">
       <Search />
       <ToolBar />
     </header>

--- a/client/src/app/components/layout/HeaderControlButton.tsx
+++ b/client/src/app/components/layout/HeaderControlButton.tsx
@@ -1,0 +1,90 @@
+import MoonSvg from '@components/svgs/MoonSvg';
+import StudioSvg from '@components/svgs/StudioSvg';
+import SunSvg from '@components/svgs/SunSvg';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+type HeaderControlButtonType = keyof typeof headerControlButtonType;
+
+const headerControlButtonType = {
+  STUDIO: 'STUDIO' as const,
+  DARK: 'DARK' as const,
+  LIGHT: 'LIGHT' as const,
+};
+
+const headerControlButtonTextContent = {
+  STUDIO: '스튜디오' as const,
+  DARK: '밝은 테마' as const,
+  LIGHT: '어두운 테마' as const,
+};
+
+type Props = {
+  componentType: HeaderControlButtonType;
+  onClick: () => void;
+};
+
+const getButtonContent = (componentType: HeaderControlButtonType) => {
+  switch (componentType) {
+    case headerControlButtonType.STUDIO:
+      return headerControlButtonTextContent.STUDIO;
+    case headerControlButtonType.DARK:
+      return headerControlButtonTextContent.DARK;
+    case headerControlButtonType.LIGHT:
+      return headerControlButtonTextContent.LIGHT;
+    default:
+      return '';
+  }
+};
+
+const HeaderControlButton = ({ componentType, onClick }: Props) => {
+  const [isHover, setIsHover] = useState(false);
+  const handleMouseEnter = () => {
+    setIsHover(true);
+  };
+  const handleMouseLeave = () => {
+    setIsHover(false);
+  };
+  return (
+    <div className={clsx('relative h-10 w-10')}>
+      <button
+        className={clsx(
+          'inline-flex h-full w-full items-center justify-center overflow-hidden rounded-md',
+          'text-content-neutral-primary',
+          'hover:bg-surface-neutral-strong bg-transparent',
+        )}
+        onClick={onClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <HeaderControlIcon componentType={componentType} />
+      </button>
+      {isHover && (
+        <span
+          className={clsx(
+            'absolute left-1/2 top-[calc(100%+0.25rem)] -translate-x-1/2',
+            'flex items-center px-2 py-1',
+            'funch-medium12 text-content-neutral-primary whitespace-nowrap',
+            'bg-surface-neutral-strong rounded-md',
+          )}
+        >
+          {getButtonContent(componentType)}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const HeaderControlIcon = ({ componentType }: { componentType: HeaderControlButtonType }) => {
+  if (componentType === headerControlButtonType.STUDIO) {
+    return <StudioSvg />;
+  }
+  if (componentType === headerControlButtonType.DARK) {
+    return <MoonSvg />;
+  }
+  if (componentType === headerControlButtonType.LIGHT) {
+    return <SunSvg />;
+  }
+  return null;
+};
+
+export default HeaderControlButton;

--- a/client/src/app/components/layout/StudioBtn.tsx
+++ b/client/src/app/components/layout/StudioBtn.tsx
@@ -1,16 +1,17 @@
-import StudioSvg from '@components/svgs/StudioSvg';
+'use client';
+
+import useInternalRouter from '@hooks/useInternalRouter';
+import HeaderControlButton from './HeaderControlButton';
 
 const StudioBtn = () => {
+  const { push } = useInternalRouter();
   return (
-    <button
-      className="hover:bg-surface-neutral-weak text-content-static-white group relative rounded-md p-2"
-      aria-label="스튜디오 페이지로"
-    >
-      <StudioSvg />
-      <span className="bg-surface-neutral-strong absolute left-[-30%] top-14 w-20 rounded-md p-1 text-center opacity-0 group-hover:opacity-100">
-        스튜디오
-      </span>
-    </button>
+    <HeaderControlButton
+      componentType="STUDIO"
+      onClick={() => {
+        push('/studio');
+      }}
+    />
   );
 };
 

--- a/client/src/app/components/layout/ThemeController.tsx
+++ b/client/src/app/components/layout/ThemeController.tsx
@@ -1,17 +1,18 @@
-import MoonSvg from '@components/svgs/MoonSvg';
+'use client';
+
+import { useState } from 'react';
+import HeaderControlButton from './HeaderControlButton';
 
 const ThemeController = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
   return (
-    // button으로 바꾸기!
-    <div
-      className="hover:bg-surface-neutral-weak text-content-static-white group relative flex rounded-md bg-inherit"
-      aria-label="밝은 테마로 변경"
-    >
-      <MoonSvg />
-      <span className="bg-surface-neutral-strong absolute left-[-30%] top-14 w-20 rounded-md p-1 text-center opacity-0 group-hover:opacity-100">
-        밝은 테마
-      </span>
-    </div>
+    <>
+      {theme === 'light' ? (
+        <HeaderControlButton componentType="DARK" onClick={() => setTheme('dark')} />
+      ) : (
+        <HeaderControlButton componentType="LIGHT" onClick={() => setTheme('light')} />
+      )}
+    </>
   );
 };
 

--- a/client/src/app/components/layout/ToolBar.tsx
+++ b/client/src/app/components/layout/ToolBar.tsx
@@ -11,18 +11,23 @@ import LogoutBtn from './LogoutBtn';
 const ToolBar = () => {
   const { isLoggedin } = useUser();
   return (
-    <div className="bg-bg-base flex w-full items-center justify-between px-4">
-      <h1 className="w-16">
-        <a href="/" title="펀치 홈으로">
-          <FunchSvg />
-          <span className="absolute left-[-9999px] top-[-9999px] h-0 w-0">펀치</span>
+    <div className="bg-bg-base flex h-full w-full items-center justify-between px-4">
+      <h1>
+        <a href="/" title="펀치 홈으로" className="relative grid h-12 grid-cols-[2.5rem,1fr] items-center gap-1">
+          <span className="inline-flex h-full w-12 items-center justify-center">
+            <FunchSvg />
+          </span>
+          <span aria-hidden className="funch-bold20 text-content-brand-base dark:text-content-static-white">
+            FUNCH
+          </span>
+          <span className="absolute left-[-9999px] top-[-9999px] h-0 w-0 overflow-hidden">펀치</span>
         </a>
       </h1>
       <div className="flex items-center gap-4">
-        <section className="flex h-full items-center gap-1">
+        <div className="flex h-full items-center gap-1">
           <ThemeController />
-          <StudioBtn />
-        </section>
+          {isLoggedin && <StudioBtn />}
+        </div>
         {isLoggedin ? <LogoutBtn /> : <LoginBtn />}
       </div>
     </div>

--- a/client/src/app/components/livesGrid/Lives.tsx
+++ b/client/src/app/components/livesGrid/Lives.tsx
@@ -5,6 +5,7 @@ import AccordionButton from '@components/AccordionButton';
 import LiveSvg from '@components/svgs/LiveSvg';
 import type { Live } from '@libs/internalTypes';
 import clsx from 'clsx';
+import Image from 'next/image';
 import Link from 'next/link';
 import { type ReactNode, type PropsWithChildren, useState } from 'react';
 
@@ -55,15 +56,22 @@ const Live = ({ live }: LiveProps) => {
         href={`/lives/${live.id}`}
         className={clsx('relative block h-44 overflow-hidden', 'rounded-xl border-0 border-solid border-transparent')}
       >
-        <div className="h-full w-full bg-orange-100" />
+        <div className="relative h-full w-full">
+          <Image
+            src={live.thumbnail}
+            fill={true}
+            sizes="100%"
+            alt={`스트리머 ${live.streamer.name}가 스트리밍 중인 영상의 섬네일`}
+          />
+        </div>
         <LiveBadge viewers={live.viewers} />
       </Link>
       <div className={clsx('mt-3 grid grid-cols-[2.5rem,1fr] gap-2.5')}>
-        <div className="h-10 w-full overflow-hidden rounded-full">
-          <img
-            width="100%"
-            height="100%"
+        <div className="relative h-10 w-full overflow-hidden rounded-full">
+          <Image
             src={live.streamer.profileImage}
+            fill={true}
+            sizes="100%"
             alt={`스트리머 ${live.streamer.name}의 프로필 이미지`}
           />
         </div>

--- a/client/src/app/components/svgs/FunchSvg.tsx
+++ b/client/src/app/components/svgs/FunchSvg.tsx
@@ -2,7 +2,15 @@ import type { SvgComponentProps } from '@libs/internalTypes';
 
 const FunchSvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
   return (
-    <svg role="img" aria-hidden={true} focusable={false} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <svg
+      role="img"
+      aria-hidden={true}
+      focusable={false}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 200 200"
+      width={40}
+      height={40}
+    >
       {svgTitle && <title>{svgTitle}</title>}
       {svgDescription && <desc>{svgDescription}</desc>}
       <rect x="40" y="50" width="120" height="100" rx="15" fill="var(--content-brand-base)" />

--- a/client/src/app/components/svgs/MoonSvg.tsx
+++ b/client/src/app/components/svgs/MoonSvg.tsx
@@ -2,7 +2,7 @@ import type { SvgComponentProps } from '@libs/internalTypes';
 
 const MoonSvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
   return (
-    <svg width="50" height="50" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
       {svgTitle && <title>{svgTitle}</title>}
       {svgDescription && <desc>{svgDescription}</desc>}
       <path

--- a/client/src/app/components/svgs/StudioSvg.tsx
+++ b/client/src/app/components/svgs/StudioSvg.tsx
@@ -2,14 +2,7 @@ import type { SvgComponentProps } from '@libs/internalTypes';
 
 const StudioSvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="35"
-      height="35"
-      viewBox="0 0 15 16"
-      fill="none"
-      className="toolbar_icon__Nh7GG"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="26" viewBox="0 0 15 16" fill="none">
       {svgTitle && <title>{svgTitle}</title>}
       {svgDescription && <desc>{svgDescription}</desc>}
       <path

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -80,9 +80,14 @@
   --surface-neutral-base: var(--neutral-2);
   --surface-neutral-strong: var(--neutral-5);
   --surface-neutral-inverse: var(--neutral-95);
-  --surface-brand-weak: var(--brand-10);
+
+  /* --surface-brand-weak: var(--brand-10);
   --surface-brand-base: var(--brand-40);
-  --surface-brand-strong: var(--brand-45);
+  --surface-brand-strong: var(--brand-45); */
+  --surface-brand-weak: var(--violet-10);
+  --surface-brand-base: var(--violet-40);
+  --surface-brand-strong: var(--violet-50);
+
   --surface-red-base: var(--red-30);
   --surface-red-strong: var(--red-50);
   --surface-violet-base: var(--violet-50);
@@ -99,9 +104,14 @@
   --content-neutral-weak: var(--neutral-30);
   --content-neutral-base: var(--neutral-40);
   --content-neutral-strong: var(--neutral-50);
-  --content-brand-weak: var(--brand-40);
+
+  /* --content-brand-weak: var(--brand-40);
   --content-brand-base: var(--brand-45);
-  --content-brand-strong: var(--brand-50);
+  --content-brand-strong: var(--brand-50); */
+  --content-brand-weak: var(--violet-30);
+  --content-brand-base: var(--violet-40);
+  --content-brand-strong: var(--violet-50);
+
   --content-red-base: var(--red-30);
   --content-red-strong: var(--red-50);
   --content-static-white: var(--neutral-0);
@@ -112,9 +122,14 @@
   --border-neutral-weak: var(--neutral-7);
   --border-neutral-base: var(--neutral-10);
   --border-neutral-strong: var(--coolgray-30);
-  --border-brand-weak: var(--brand-30);
+
+  /* --border-brand-weak: var(--brand-30);
   --border-brand-base: var(--brand-45);
-  --border-brand-strong: var(--brand-50);
+  --border-brand-strong: var(--brand-50); */
+  --border-brand-weak: var(--violet-30);
+  --border-brand-base: var(--violet-40);
+  --border-brand-strong: var(--violet-50);
+
   --border-red-base: var(--red-30);
   --border-red-strong: var(--red-50);
   --border-static-white: var(--neutral-0);
@@ -136,9 +151,14 @@
     --surface-neutral-base: var(--neutral-50);
     --surface-neutral-strong: var(--neutral-40);
     --surface-neutral-inverse: var(--neutral-0);
-    --surface-brand-weak: var(--brand-80);
+
+    /* --surface-brand-weak: var(--brand-80);
     --surface-brand-base: var(--brand-60);
-    --surface-brand-strong: var(--brand-55);
+    --surface-brand-strong: var(--brand-55); */
+    --surface-brand-weak: var(--violet-80);
+    --surface-brand-base: var(--violet-60);
+    --surface-brand-strong: var(--violet-50);
+
     --surface-red-base: var(--red-30);
     --surface-red-strong: var(--red-50);
     --surface-violet-base: var(--violet-50);
@@ -154,9 +174,14 @@
     --content-neutral-weak: var(--neutral-50);
     --content-neutral-base: var(--neutral-30);
     --content-neutral-strong: var(--neutral-20);
-    --content-brand-weak: var(--brand-70);
+
+    /* --content-brand-weak: var(--brand-70);
     --content-brand-base: var(--brand-55);
-    --content-brand-strong: var(--brand-50);
+    --content-brand-strong: var(--brand-50); */
+    --content-brand-weak: var(--violet-70);
+    --content-brand-base: var(--violet-60);
+    --content-brand-strong: var(--violet-50);
+
     --content-red-base: var(--red-30);
     --content-red-strong: var(--red-50);
     --content-static-white: var(--neutral-0);
@@ -167,9 +192,14 @@
     --border-neutral-weak: var(--neutral-50);
     --border-neutral-base: var(--neutral-40);
     --border-neutral-strong: var(--coolgray-50);
-    --border-brand-weak: var(--brand-70);
+
+    /* --border-brand-weak: var(--brand-70);
     --border-brand-base: var(--brand-55);
-    --border-brand-strong: var(--brand-50);
+    --border-brand-strong: var(--brand-50); */
+    --border-brand-weak: var(--violet-70);
+    --border-brand-base: var(--violet-60);
+    --border-brand-strong: var(--violet-50);
+
     --border-red-base: var(--red-30);
     --border-red-strong: var(--red-50);
     --border-static-white: var(--neutral-0);

--- a/client/src/app/hooks/useInternalRouter.ts
+++ b/client/src/app/hooks/useInternalRouter.ts
@@ -1,0 +1,14 @@
+import type { InternalPath } from '@libs/internalTypes';
+import { useRouter } from 'next/navigation';
+
+const useInternalRouter = () => {
+  const router = useRouter();
+
+  return {
+    push: (path: InternalPath) => router.push(path),
+    replace: (path: InternalPath) => router.replace(path),
+    back: () => router.back(),
+  };
+};
+
+export default useInternalRouter;

--- a/client/src/app/studio/page.tsx
+++ b/client/src/app/studio/page.tsx
@@ -1,0 +1,5 @@
+const StudioPage = () => {
+  return <div>StudioPage</div>;
+};
+
+export default StudioPage;

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from 'tailwindcss';
 import tailwindPlugins from './plugins/tailwind.plugin';
 
-const HEADER_HEIGHT = '3.75rem';
+// const HEADER_HEIGHT = '3.75rem'; // 60px
+const HEADER_HEIGHT = '5rem'; // 80px
 const HOME_MIN_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
 const LAYOUT_MIN_WIDTH = '58.125rem';
 


### PR DESCRIPTION
## Issue

- [x] #30 


<br><br>

## Detail

- header 내 컨트롤 버튼들을 HeaderControlButton 컴포넌트로 통합
- Image 컴포넌트 사용
- brand 색상이 violet 사용하도록 변경
- useInternalRouter hook