### PR TITLE
feat: 라이브 목록 아이템의 반응형 높이, 검색창 반응형 너비

### DIFF
--- a/client/configs/tailwind.constant.ts
+++ b/client/configs/tailwind.constant.ts
@@ -1,0 +1,11 @@
+export const LAYOUT_MIN_WIDTH = '58.125rem';
+export const HEADER_HEIGHT = '5rem'; // 80px
+
+export const HOME_MIN_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
+
+export const LIVE_X_GAP = '0.875rem'; // 14px
+export const LIVE_WIDTH = `calc(33.332% - (${LIVE_X_GAP} * 2 / 3))`;
+export const LIVE_ASPECT_RATIO = '56.25%'; // 16:9
+
+export const SEARCH_WIDTH = 'calc(100% - 41.25rem)'; // 660px = 41.25rem
+export const SEARCH_WIDTH_WIDE = 'calc(100% - 58.125rem)'; // 930px = 58.125rem

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,8 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: [
-      'via.placeholder.com', // sample domain for test
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+      }, // sample domain for test
     ],
   },
 };

--- a/client/src/app/components/layout/SearchView.tsx
+++ b/client/src/app/components/layout/SearchView.tsx
@@ -13,7 +13,7 @@ const SearchWrapper = ({ children, onSubmit }: SearchWrapperProps) => {
   return (
     <div
       className={clsx(
-        'absolute left-1/2 top-1/2 w-96 -translate-x-1/2 -translate-y-1/2',
+        'w-search funch-desktop:w-search-wide absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
         'border-border-neutral-base focus-within:border-border-brand-weak rounded-full border border-solid',
       )}
     >

--- a/client/src/app/components/livesGrid/LiveBadge.tsx
+++ b/client/src/app/components/livesGrid/LiveBadge.tsx
@@ -1,0 +1,16 @@
+import LiveSvg from '@components/svgs/LiveSvg';
+
+const LiveBadge = ({ viewers }: { viewers: number }) => {
+  return (
+    <div aria-hidden className="absolute left-1.5 top-1 flex h-5 gap-1">
+      <span className="bg-surface-red-strong inline-flex h-full items-center rounded-md px-1">
+        <LiveSvg />
+      </span>
+      <span className="funch-bold12 text-content-static-white inline-flex h-full items-center rounded-md bg-[rgba(20,21,23,.9)] px-1">
+        {viewers}명
+      </span>
+    </div>
+  );
+};
+
+export default LiveBadge;

--- a/client/src/app/components/livesGrid/Lives.tsx
+++ b/client/src/app/components/livesGrid/Lives.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import Badge from '@/app/features/Badge';
+import Badge from '@app/features/Badge';
 import AccordionButton from '@components/AccordionButton';
-import LiveSvg from '@components/svgs/LiveSvg';
 import type { Live } from '@libs/internalTypes';
 import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
 import { type ReactNode, type PropsWithChildren, useState } from 'react';
+import LiveBadge from './LiveBadge';
 
 type ChildrenArgs = {
   visibleLives: Live[];
@@ -41,7 +41,7 @@ const ExpandButton = ({ isExpanded, toggle }: { isExpanded: boolean; toggle: () 
 };
 
 const LivesList = ({ children }: PropsWithChildren) => {
-  return <div className={clsx('flex flex-wrap gap-x-3.5 gap-y-7')}>{children}</div>;
+  return <div className={clsx('gap-x-liveX flex flex-wrap gap-y-7')}>{children}</div>;
 };
 
 type LiveProps = {
@@ -50,13 +50,16 @@ type LiveProps = {
 
 const Live = ({ live }: LiveProps) => {
   return (
-    <div className={clsx('w-[calc(33.3334%-9.3334px)]')}>
+    <div className={clsx('w-live')}>
       <Link
         aria-label={`${live.viewers}명이 보고 있는 방송 보러가기, 제목 '${live.title}'`}
         href={`/lives/${live.id}`}
-        className={clsx('relative block h-44 overflow-hidden', 'rounded-xl border-0 border-solid border-transparent')}
+        className={clsx(
+          'pb-liveAspectRatio relative block overflow-hidden',
+          'rounded-xl border-0 border-solid border-transparent',
+        )}
       >
-        <div className="relative h-full w-full">
+        <div className="absolute left-0 top-0 h-full w-full">
           <Image
             src={live.thumbnail}
             fill={true}
@@ -86,19 +89,6 @@ const Live = ({ live }: LiveProps) => {
           </div>
         </div>
       </div>
-    </div>
-  );
-};
-
-const LiveBadge = ({ viewers }: { viewers: number }) => {
-  return (
-    <div aria-hidden className="absolute left-1.5 top-1 flex h-5 gap-1">
-      <span className="bg-surface-red-strong inline-flex h-full items-center rounded-md px-1">
-        <LiveSvg />
-      </span>
-      <span className="funch-bold12 text-content-static-white inline-flex h-full items-center rounded-md bg-[rgba(20,21,23,.9)] px-1">
-        {viewers}명
-      </span>
     </div>
   );
 };

--- a/client/src/app/components/livesGrid/Lives.tsx
+++ b/client/src/app/components/livesGrid/Lives.tsx
@@ -41,7 +41,7 @@ const ExpandButton = ({ isExpanded, toggle }: { isExpanded: boolean; toggle: () 
 };
 
 const LivesList = ({ children }: PropsWithChildren) => {
-  return <div className={clsx('gap-x-liveX flex flex-wrap gap-y-7')}>{children}</div>;
+  return <div className={clsx('gap-x-live-x flex flex-wrap gap-y-7')}>{children}</div>;
 };
 
 type LiveProps = {
@@ -55,7 +55,7 @@ const Live = ({ live }: LiveProps) => {
         aria-label={`${live.viewers}명이 보고 있는 방송 보러가기, 제목 '${live.title}'`}
         href={`/lives/${live.id}`}
         className={clsx(
-          'pb-liveAspectRatio relative block overflow-hidden',
+          'pb-live-aspect-ratio relative block overflow-hidden',
           'rounded-xl border-0 border-solid border-transparent',
         )}
       >

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -35,10 +35,10 @@ const config: Config = {
       },
       padding: {
         header: HEADER_HEIGHT,
-        liveAspectRatio: LIVE_ASPECT_RATIO,
+        'live-aspect-ratio': LIVE_ASPECT_RATIO,
       },
       gap: {
-        liveX: LIVE_X_GAP,
+        'live-x': LIVE_X_GAP,
       },
       colors: {
         // Neutral 색상

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,10 +1,13 @@
 import type { Config } from 'tailwindcss';
 import tailwindPlugins from './plugins/tailwind.plugin';
 
-// const HEADER_HEIGHT = '3.75rem'; // 60px
 const HEADER_HEIGHT = '5rem'; // 80px
 const HOME_MIN_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
 const LAYOUT_MIN_WIDTH = '58.125rem';
+
+const LIVE_X_GAP = '0.875rem'; // 14px
+const LIVE_WIDTH = `calc(33.332% - (${LIVE_X_GAP} * 2 / 3))`;
+const LIVE_ASPECT_RATIO = '56.25%'; // 16:9
 
 const config: Config = {
   content: [
@@ -18,6 +21,9 @@ const config: Config = {
       screens: {
         'funch-desktop': '1200px',
       },
+      width: {
+        live: LIVE_WIDTH,
+      },
       height: {
         header: HEADER_HEIGHT,
       },
@@ -29,6 +35,10 @@ const config: Config = {
       },
       padding: {
         header: HEADER_HEIGHT,
+        liveAspectRatio: LIVE_ASPECT_RATIO,
+      },
+      gap: {
+        liveX: LIVE_X_GAP,
       },
       colors: {
         // Neutral 색상

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,13 +1,19 @@
 import type { Config } from 'tailwindcss';
 import tailwindPlugins from './plugins/tailwind.plugin';
-
-const HEADER_HEIGHT = '5rem'; // 80px
-const HOME_MIN_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
-const LAYOUT_MIN_WIDTH = '58.125rem';
-
-const LIVE_X_GAP = '0.875rem'; // 14px
-const LIVE_WIDTH = `calc(33.332% - (${LIVE_X_GAP} * 2 / 3))`;
-const LIVE_ASPECT_RATIO = '56.25%'; // 16:9
+import {
+  // layout
+  LAYOUT_MIN_WIDTH,
+  HEADER_HEIGHT,
+  // home
+  HOME_MIN_HEIGHT,
+  // live
+  LIVE_X_GAP,
+  LIVE_WIDTH,
+  LIVE_ASPECT_RATIO,
+  // search
+  SEARCH_WIDTH,
+  SEARCH_WIDTH_WIDE,
+} from './configs/tailwind.constant';
 
 const config: Config = {
   content: [
@@ -23,6 +29,8 @@ const config: Config = {
       },
       width: {
         live: LIVE_WIDTH,
+        search: SEARCH_WIDTH,
+        'search-wide': SEARCH_WIDTH_WIDE,
       },
       height: {
         header: HEADER_HEIGHT,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,12 +18,14 @@
       }
     ],
     "paths": {
+      "@test/*": ["./src/app/__test__/*"],
       "@mocks/*": ["./src/app/__mocks__/*"],
       "@hooks/*": ["./src/app/hooks/*"],
       "@providers/*": ["./src/app/providers/*"],
       "@libs/*": ["./src/app/libs/*"],
       "@components/*": ["./src/app/components/*"],
       "@server/*": ["./src/app/server/*"],
+      "@app/*": ["./src/app/*"],
       "@/*": ["./src/*"]
     }
   },

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -6,9 +6,14 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      '@test': fileURLToPath(new URL('./src/__test__', import.meta.url)),
+      '@mocks': fileURLToPath(new URL('./src/__mocks__', import.meta.url)),
+      '@hooks': fileURLToPath(new URL('./src/app/hooks', import.meta.url)),
+      '@providers': fileURLToPath(new URL('./src/app/providers', import.meta.url)),
       '@libs': fileURLToPath(new URL('./src/app/libs', import.meta.url)),
       '@components': fileURLToPath(new URL('./src/app/components', import.meta.url)),
       '@server': fileURLToPath(new URL('./src/app/server', import.meta.url)),
+      '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },


### PR DESCRIPTION
## Issue

- [x] #24 
- [x] #29 


<br><br>

## Detail

- 라이브 목록 요소의 높이도 화면 사이즈에 따라 변화하도록 테일윈드 설정 추가 및 코드 수정
- 컨벤션에 맞게 테일윈드 변수명 일부 변경
- 검색창 너비에 대한 변수를 설정하고 화면 너비에 따라 달리 사용
- deprecated인 domains 옵션을 사용하지 않고, RemotePatterns 사용 (next.config)