### PR TITLE
feat: 라이브 섹션 및 라이브 프로바이더, 컨트롤러 기능 등 프로토타입 작성 진행

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "hls.js": "^1.5.17",
         "next": "14.2.16",
         "react": "^18",
         "react-dom": "^18"
@@ -4412,6 +4413,12 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
+    },
+    "node_modules/hls.js": {
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.17.tgz",
+      "integrity": "sha512-wA66nnYFvQa1o4DO/BFgLNRKnBTVXpNeldGRBJ2Y0SvFtdwvFKCbqa9zhHoZLoxHhZ+jYsj3aIBkWQQCPNOhMw==",
+      "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "hls.js": "^1.5.17",
     "next": "14.2.16",
     "react": "^18",
     "react-dom": "^18"

--- a/client/src/app/GlobalProvider.tsx
+++ b/client/src/app/GlobalProvider.tsx
@@ -9,7 +9,7 @@ type Props = PropsWithChildren;
 const GlobalProvider = ({ children }: Props) => {
   return (
     <ThemeProvider>
-      <UserProvider>{children}</UserProvider>;
+      <UserProvider>{children}</UserProvider>
     </ThemeProvider>
   );
 };

--- a/client/src/app/components/cabinet/FollowList.tsx
+++ b/client/src/app/components/cabinet/FollowList.tsx
@@ -56,7 +56,7 @@ const Follow = ({ follow, isDesktop }: { follow: Live; isDesktop: boolean }) => 
               </section>
             </div>
           </div>
-          <div className="text-content-neutral-primary border-neutral-weak bg-surface-neutral-strong absolute left-52 top-0 z-50 flex h-20 w-60 items-center rounded-md p-4 opacity-0 peer-hover:opacity-100">
+          <div className="text-content-neutral-primary border-neutral-weak bg-surface-neutral-strong absolute left-52 top-0 z-50 hidden h-20 w-60 items-center rounded-md p-4 peer-hover:flex">
             {follow.title}
           </div>
         </div>
@@ -72,7 +72,7 @@ const Follow = ({ follow, isDesktop }: { follow: Live; isDesktop: boolean }) => 
             />
           </div>
           {follow.isStreaming && (
-            <div className="bg-surface-neutral-base z-100 absolute left-14 top-3 flex h-32 w-52 flex-col rounded-md p-3 opacity-0 peer-hover:opacity-100">
+            <div className="bg-surface-neutral-base z-100 absolute left-14 top-3 hidden h-32 w-52 flex-col rounded-md p-3 peer-hover:flex">
               <div className="flex h-1/4 w-full items-center gap-2 truncate">
                 <div className="text-content-brand-strong funch-bold16">{follow.streamer.name}</div>
                 <div className="funch-bold14 border-border-neutral-base rounded-md border-2 p-[3px]">

--- a/client/src/app/components/svgs/NotifySvg.tsx
+++ b/client/src/app/components/svgs/NotifySvg.tsx
@@ -1,0 +1,25 @@
+import type { SvgComponentProps } from '@libs/internalTypes';
+import React from 'react';
+
+const NotifySvg = ({ svgTitle, svgDescription }: SvgComponentProps) => {
+  return (
+    <svg
+      viewBox="0 0 70 70"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      width="70"
+      height="70"
+      role="img"
+      focusable="false"
+      aria-hidden="true"
+    >
+      {svgTitle && <title>{svgTitle}</title>}
+      {svgDescription && <desc>{svgDescription}</desc>}
+      <circle cx="35" cy="35" r="25" stroke="currentColor" strokeWidth="4"></circle>
+      <circle cx="35" cy="45.5" r="2.5" fill="currentColor" stroke="currentColor" strokeWidth="0.6"></circle>
+      <rect x="32.5" y="22" width="5" height="17" rx="2.5" fill="currentColor"></rect>
+    </svg>
+  );
+};
+
+export default NotifySvg;

--- a/client/src/app/features/live/Live.tsx
+++ b/client/src/app/features/live/Live.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+type Props = {};
+
+const LiveController = (props: Props) => {
+  return <div>Live</div>;
+};
+
+const Live = Object.assign(LiveController, {});
+
+export default Live;

--- a/client/src/app/features/live/Live.tsx
+++ b/client/src/app/features/live/Live.tsx
@@ -1,11 +1,161 @@
 'use client';
 
-type Props = {};
+import {
+  type ChangeEvent,
+  type ForwardedRef,
+  forwardRef,
+  type PropsWithChildren,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import Hls from 'hls.js';
 
-const LiveController = (props: Props) => {
-  return <div>Live</div>;
+const LiveController = ({
+  children,
+}: {
+  children: (args: {
+    isStreaming: boolean;
+    volume: number;
+    videoRef: RefObject<HTMLVideoElement>;
+    videoWrapperRef: RefObject<HTMLDivElement>;
+    play: () => void;
+    pause: () => void;
+    fullscreen: () => void;
+    pip: () => void;
+    handleChangeVolue: (e: ChangeEvent<HTMLInputElement>) => void;
+  }) => ReactNode;
+}) => {
+  // 유효한 스트리밍인지 어떻게 알 수 있을까?
+  const [isStreaming, setIsStreaming] = useState(true);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoWrapperRef = useRef<HTMLDivElement>(null);
+  const [volume, setVolume] = useState(50);
+
+  const play = () => {
+    if (videoRef.current && videoRef.current.paused) {
+      videoRef.current.play();
+    }
+  };
+
+  const fullscreen = () => {
+    if (videoWrapperRef.current && videoWrapperRef.current.requestFullscreen) {
+      videoWrapperRef.current.requestFullscreen();
+    }
+  };
+
+  const pip = () => {
+    if (videoRef.current && videoRef.current.requestPictureInPicture) {
+      videoRef.current.requestPictureInPicture();
+    }
+  };
+
+  const pause = () => {
+    if (videoRef.current && !videoRef.current.paused) {
+      videoRef.current.pause();
+    }
+  };
+
+  const handleChangeVolue = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextVolume = Number(e.target.value);
+    setVolume(nextVolume);
+  };
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.volume = volume / 100;
+    }
+  }, [volume]);
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource(
+        'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8',
+      );
+      hls.attachMedia(videoRef.current);
+
+      // hls.on(Hls.Events.MANIFEST_PARSED, () => {
+      //   videoRef.current!.play();
+      // });
+      return () => hls.destroy();
+    } else if (videoRef.current!.canPlayType('application/vnd.apple.mpegurl')) {
+      videoRef.current.src =
+        'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
+      videoRef.current.addEventListener('loadedmetadata', () => {
+        videoRef.current!.play();
+      });
+    }
+  }, []);
+
+  return children({
+    isStreaming,
+    volume,
+    videoRef,
+    videoWrapperRef,
+    play,
+    pause,
+    fullscreen,
+    pip,
+    handleChangeVolue,
+  });
 };
 
-const Live = Object.assign(LiveController, {});
+const VideoWrapper = forwardRef(({ children }: PropsWithChildren, ref: ForwardedRef<HTMLDivElement>) => {
+  return (
+    <div className="w-full" ref={ref}>
+      {children}
+    </div>
+  );
+});
+
+const Video = forwardRef(({}: {}, ref: ForwardedRef<HTMLVideoElement>) => {
+  return (
+    <div className="pb-live-aspect-ratio relative w-full">
+      <div className="absolute left-0 top-0 h-full w-full">
+        <video ref={ref} controls autoPlay controlsList="nodownload" width="100%" height="100%" playsInline />
+      </div>
+    </div>
+  );
+});
+
+const PlayButton = ({ play }: { play: () => void }) => {
+  return <button onClick={play}>재생</button>;
+};
+
+const FullscreenButton = ({ fullscreen }: { fullscreen: () => void }) => {
+  return <button onClick={fullscreen}>풀스크린</button>;
+};
+
+const PipButton = ({ pip }: { pip: () => void }) => {
+  return <button onClick={pip}>PIP</button>;
+};
+
+const PauseButton = ({ pause }: { pause: () => void }) => {
+  return <button onClick={pause}>일시정지</button>;
+};
+
+const VolumeController = ({
+  volume,
+  handleChangeVolue,
+}: {
+  volume: number;
+  handleChangeVolue: (e: ChangeEvent<HTMLInputElement>) => void;
+}) => {
+  return <input type="range" min="0" max="100" value={volume} onChange={handleChangeVolue} />;
+};
+
+const Live = Object.assign(LiveController, {
+  VideoWrapper,
+  Video,
+  Play: PlayButton,
+  Fullscreen: FullscreenButton,
+  Pip: PipButton,
+  Pause: PauseButton,
+  Volume: VolumeController,
+});
 
 export default Live;

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -2,15 +2,16 @@
 
 import { usePathname } from 'next/navigation';
 import LiveProvider from '@providers/LiveProvider';
-import { type ReactNode, useRef, useState } from 'react';
+import { type ChangeEvent, type ReactNode, useEffect, useRef, useState } from 'react';
 import NoLiveContent from './NoLiveContent';
 
 const LiveSection = () => {
   const ref = useRef<HTMLVideoElement>(null);
   const pathname = usePathname();
+  const [volume, setVolume] = useState(50);
 
   const play = () => {
-    if (ref.current) {
+    if (ref.current && ref.current.paused) {
       ref.current.play();
     }
   };
@@ -26,6 +27,23 @@ const LiveSection = () => {
       ref.current.requestPictureInPicture();
     }
   };
+
+  const pause = () => {
+    if (ref.current && !ref.current.paused) {
+      ref.current.pause();
+    }
+  };
+
+  const handleChangeVolue = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextVolume = Number(e.target.value);
+    setVolume(nextVolume);
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.volume = volume / 100;
+    }
+  }, [volume]);
 
   if (pathname.split('/')[1] !== 'lives') return null;
 
@@ -50,6 +68,8 @@ const LiveSection = () => {
                 <PlayButton play={play} />
                 <FullscreenButton fullscreen={fullscreen} />
                 <PipButton pip={pip} />
+                <PauseButton pause={pause} />
+                <VolumeController volume={volume} handleChangeVolue={handleChangeVolue} />
               </div>
             ) : (
               <NoLiveContent />
@@ -71,6 +91,20 @@ const FullscreenButton = ({ fullscreen }: { fullscreen: () => void }) => {
 
 const PipButton = ({ pip }: { pip: () => void }) => {
   return <button onClick={pip}>PIP</button>;
+};
+
+const PauseButton = ({ pause }: { pause: () => void }) => {
+  return <button onClick={pause}>일시정지</button>;
+};
+
+const VolumeController = ({
+  volume,
+  handleChangeVolue,
+}: {
+  volume: number;
+  handleChangeVolue: (e: ChangeEvent<HTMLInputElement>) => void;
+}) => {
+  return <input type="range" min="0" max="100" value={volume} onChange={handleChangeVolue} />;
 };
 
 const LiveController = ({ children }: { children: (args: { isStreaming: boolean }) => ReactNode }) => {

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -17,8 +17,12 @@ const LiveSection = () => {
   };
 
   const fullscreen = () => {
-    if (ref.current) {
-      ref.current.requestFullscreen();
+    // if (ref.current) {
+    //   ref.current.requestFullscreen();
+    // }
+    const div = document.getElementById('test-div');
+    if (div) {
+      div.requestFullscreen();
     }
   };
 
@@ -53,24 +57,32 @@ const LiveSection = () => {
         <LiveController>
           {({ isStreaming }) =>
             isStreaming ? (
-              <div className="pl-60" id="test-div">
-                <video
-                  ref={ref}
-                  controls
-                  controlsList="nodownload"
-                  className="relative"
-                  id="test-video"
-                  src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
-                  width={600}
-                >
-                  <p className="text-red-5 absolute left-0 top-0">hihih</p>
-                </video>
-                <PlayButton play={play} />
-                <FullscreenButton fullscreen={fullscreen} />
-                <PipButton pip={pip} />
-                <PauseButton pause={pause} />
-                <VolumeController volume={volume} handleChangeVolue={handleChangeVolue} />
-              </div>
+              <>
+                <div className="w-full" id="test-div">
+                  <div className="pb-live-aspect-ratio relative w-full">
+                    <div className="absolute left-0 top-0 h-full w-full">
+                      <video
+                        ref={ref}
+                        controlsList="nodownload"
+                        id="test-video"
+                        src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+                        width="100%"
+                        height="100%"
+                        playsInline
+                        webkit-playsinline
+                        x-webkit-airplay
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <PlayButton play={play} />
+                  <FullscreenButton fullscreen={fullscreen} />
+                  <PipButton pip={pip} />
+                  <PauseButton pause={pause} />
+                  <VolumeController volume={volume} handleChangeVolue={handleChangeVolue} />
+                </div>
+              </>
             ) : (
               <NoLiveContent />
             )

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -1,128 +1,49 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import LiveProvider from '@providers/LiveProvider';
-import { type ChangeEvent, type ReactNode, useEffect, useRef, useState } from 'react';
 import NoLiveContent from './NoLiveContent';
+import Live from './Live';
 
 const LiveSection = () => {
-  const ref = useRef<HTMLVideoElement>(null);
   const pathname = usePathname();
-  const [volume, setVolume] = useState(50);
-
-  const play = () => {
-    if (ref.current && ref.current.paused) {
-      ref.current.play();
-    }
-  };
-
-  const fullscreen = () => {
-    // if (ref.current) {
-    //   ref.current.requestFullscreen();
-    // }
-    const div = document.getElementById('test-div');
-    if (div) {
-      div.requestFullscreen();
-    }
-  };
-
-  const pip = () => {
-    if (ref.current) {
-      ref.current.requestPictureInPicture();
-    }
-  };
-
-  const pause = () => {
-    if (ref.current && !ref.current.paused) {
-      ref.current.pause();
-    }
-  };
-
-  const handleChangeVolue = (e: ChangeEvent<HTMLInputElement>) => {
-    const nextVolume = Number(e.target.value);
-    setVolume(nextVolume);
-  };
-
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.volume = volume / 100;
-    }
-  }, [volume]);
 
   if (pathname.split('/')[1] !== 'lives') return null;
+
+  const { id } = useParams();
+  console.log('id', id); // <- hls id? live streaming id?
+  // 이 id 값으로 현재 스트리밍이 유효한지 알려주는 API를 호출해야 할 것 같다.
+  // false -> NoLiveContent
+  // true -> Live
 
   return (
     <LiveProvider>
       <section>
-        <LiveController>
-          {({ isStreaming }) =>
-            isStreaming ? (
-              <>
-                <div className="w-full" id="test-div">
-                  <div className="pb-live-aspect-ratio relative w-full">
-                    <div className="absolute left-0 top-0 h-full w-full">
-                      <video
-                        ref={ref}
-                        controlsList="nodownload"
-                        id="test-video"
-                        src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
-                        width="100%"
-                        height="100%"
-                        playsInline
-                        webkit-playsinline
-                        x-webkit-airplay
-                      />
-                    </div>
+        <Live>
+          {({ isStreaming, videoRef, videoWrapperRef, play, pause, fullscreen, pip, volume, handleChangeVolue }) => (
+            <>
+              {isStreaming ? (
+                <>
+                  <Live.VideoWrapper ref={videoWrapperRef}>
+                    <Live.Video ref={videoRef} />
+                  </Live.VideoWrapper>
+                  <div>
+                    <Live.Play play={play} />
+                    <Live.Fullscreen fullscreen={fullscreen} />
+                    <Live.Pip pip={pip} />
+                    <Live.Pause pause={pause} />
+                    <Live.Volume volume={volume} handleChangeVolue={handleChangeVolue} />
                   </div>
-                </div>
-                <div>
-                  <PlayButton play={play} />
-                  <FullscreenButton fullscreen={fullscreen} />
-                  <PipButton pip={pip} />
-                  <PauseButton pause={pause} />
-                  <VolumeController volume={volume} handleChangeVolue={handleChangeVolue} />
-                </div>
-              </>
-            ) : (
-              <NoLiveContent />
-            )
-          }
-        </LiveController>
+                </>
+              ) : (
+                <NoLiveContent />
+              )}
+            </>
+          )}
+        </Live>
       </section>
     </LiveProvider>
   );
-};
-
-const PlayButton = ({ play }: { play: () => void }) => {
-  return <button onClick={play}>재생</button>;
-};
-
-const FullscreenButton = ({ fullscreen }: { fullscreen: () => void }) => {
-  return <button onClick={fullscreen}>풀스크린</button>;
-};
-
-const PipButton = ({ pip }: { pip: () => void }) => {
-  return <button onClick={pip}>PIP</button>;
-};
-
-const PauseButton = ({ pause }: { pause: () => void }) => {
-  return <button onClick={pause}>일시정지</button>;
-};
-
-const VolumeController = ({
-  volume,
-  handleChangeVolue,
-}: {
-  volume: number;
-  handleChangeVolue: (e: ChangeEvent<HTMLInputElement>) => void;
-}) => {
-  return <input type="range" min="0" max="100" value={volume} onChange={handleChangeVolue} />;
-};
-
-const LiveController = ({ children }: { children: (args: { isStreaming: boolean }) => ReactNode }) => {
-  const [isStreaming, setIsStreaming] = useState(true);
-
-  return children({ isStreaming });
 };
 
 export default LiveSection;

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import LiveProvider from '@providers/LiveProvider';
+import { type ReactNode, useRef, useState } from 'react';
+import NoLiveContent from './NoLiveContent';
+
+const LiveSection = () => {
+  const ref = useRef<HTMLVideoElement>(null);
+  const pathname = usePathname();
+
+  const play = () => {
+    if (ref.current) {
+      ref.current.play();
+    }
+  };
+
+  if (pathname.split('/')[1] !== 'lives') return null;
+
+  return (
+    <LiveProvider>
+      <section>
+        <LiveController>
+          {({ isStreaming }) =>
+            isStreaming ? (
+              <div className="pl-60" id="test-div">
+                <video
+                  ref={ref}
+                  controls
+                  controlsList="nodownload"
+                  className="relative"
+                  id="test-video"
+                  src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+                  width={600}
+                >
+                  <p className="text-red-5 absolute left-0 top-0">hihih</p>
+                </video>
+                <PlayButton play={play} />
+              </div>
+            ) : (
+              <NoLiveContent />
+            )
+          }
+        </LiveController>
+      </section>
+    </LiveProvider>
+  );
+};
+
+const PlayButton = ({ play }: { play: () => void }) => {
+  return <button onClick={play}>재생</button>;
+};
+
+const LiveController = ({ children }: { children: (args: { isStreaming: boolean }) => ReactNode }) => {
+  const [isStreaming, setIsStreaming] = useState(true);
+
+  return children({ isStreaming });
+};
+
+export default LiveSection;

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -15,6 +15,18 @@ const LiveSection = () => {
     }
   };
 
+  const fullscreen = () => {
+    if (ref.current) {
+      ref.current.requestFullscreen();
+    }
+  };
+
+  const pip = () => {
+    if (ref.current) {
+      ref.current.requestPictureInPicture();
+    }
+  };
+
   if (pathname.split('/')[1] !== 'lives') return null;
 
   return (
@@ -36,6 +48,8 @@ const LiveSection = () => {
                   <p className="text-red-5 absolute left-0 top-0">hihih</p>
                 </video>
                 <PlayButton play={play} />
+                <FullscreenButton fullscreen={fullscreen} />
+                <PipButton pip={pip} />
               </div>
             ) : (
               <NoLiveContent />
@@ -49,6 +63,14 @@ const LiveSection = () => {
 
 const PlayButton = ({ play }: { play: () => void }) => {
   return <button onClick={play}>재생</button>;
+};
+
+const FullscreenButton = ({ fullscreen }: { fullscreen: () => void }) => {
+  return <button onClick={fullscreen}>풀스크린</button>;
+};
+
+const PipButton = ({ pip }: { pip: () => void }) => {
+  return <button onClick={pip}>PIP</button>;
 };
 
 const LiveController = ({ children }: { children: (args: { isStreaming: boolean }) => ReactNode }) => {

--- a/client/src/app/features/live/NoLiveContent.tsx
+++ b/client/src/app/features/live/NoLiveContent.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import Button from '@components/Button';
+import NotifySvg from '@components/svgs/NotifySvg';
+
+const NoLiveContent = () => {
+  return (
+    <div className="">
+      <NotifySvg />
+      <strong>존재하지 않는 채널입니다.</strong>
+      <p>
+        지금 입력하신 주소의 페이지는
+        <br />
+        사라졌거나 다른 페이지로 변경되었습니다.
+        <br />
+        주소를 다시 확인해주세요.
+      </p>
+      <Button>다른 방송 보러가기</Button>
+    </div>
+  );
+};
+
+export default NoLiveContent;

--- a/client/src/app/hooks/useLiveContext.ts
+++ b/client/src/app/hooks/useLiveContext.ts
@@ -1,0 +1,14 @@
+import { LiveContext } from '@providers/LiveProvider';
+import { useContext } from 'react';
+
+const useLiveContext = () => {
+  const context = useContext(LiveContext);
+
+  if (!context) {
+    throw new Error('컨텍스트가 초기화되지 않았어요.');
+  }
+
+  return context;
+};
+
+export default useLiveContext;

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -6,6 +6,7 @@ import MswInitializer from './MswInitializer';
 import Header from './components/layout/Header';
 import GlobalProvider from './GlobalProvider';
 import Cabinet from '@components/cabinet/Cabinet';
+import LiveSection from './features/live/LiveSection';
 
 const notoSansKR = Noto_Sans_KR({
   weight: ['300', '500', '700'],
@@ -37,7 +38,10 @@ const RootLayout = ({
               <Header />
               <Cabinet />
               {/* {!wideView && <Cabinet />} */}
-              <Main>{children}</Main>
+              <Main>
+                {children}
+                <LiveSection />
+              </Main>
             </GlobalProvider>
           </MswInitializer>
         </Layout>

--- a/client/src/app/lives/[id]/page.tsx
+++ b/client/src/app/lives/[id]/page.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+// import React from 'react';
 
-type Props = {
-  params: Promise<{ id: string }>;
-};
+// type Props = {
+//   params: Promise<{ id: string }>;
+// };
 
-const page = async ({ params }: Props) => {
-  const id = (await params).id;
-  return <div>live id = {id}</div>;
-};
+const page = async () =>
+  // { params }: Props
+  {
+    // const id = (await params).id;
+    return null;
+  };
 
 export default page;

--- a/client/src/app/providers/LiveProvider.tsx
+++ b/client/src/app/providers/LiveProvider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createContext, useState, type PropsWithChildren } from 'react';
+
+type LiveContextType = {
+  hlsUrl: string | null;
+  changeHlsUrl: (url: string) => void;
+};
+
+export const LiveContext = createContext<LiveContextType | null>(null);
+
+const LiveProvider = ({ children }: PropsWithChildren) => {
+  const [hlsUrl, setHslUrl] = useState<string | null>(null);
+
+  const changeHlsUrl = (url: string) => {
+    setHslUrl(url);
+  };
+
+  return (
+    <LiveContext.Provider
+      value={{
+        hlsUrl,
+        changeHlsUrl,
+      }}
+    >
+      {children}
+    </LiveContext.Provider>
+  );
+};
+
+export default LiveProvider;

--- a/client/src/app/providers/UserProvider.tsx
+++ b/client/src/app/providers/UserProvider.tsx
@@ -2,6 +2,10 @@
 
 import { createContext, useState, type PropsWithChildren } from 'react';
 
+type User = {
+  name: string;
+};
+
 type UserContextType = {
   user: User | null;
   login: () => void;
@@ -37,7 +41,3 @@ const UserProvider = ({ children }: Props) => {
 };
 
 export default UserProvider;
-
-type User = {
-  name: string;
-};


### PR DESCRIPTION
## Issue

- [x] #98 


<br><br>

## Detail

- 라이브 섹션 및 라이브 프로바이더 프로토타입 작성
- play, pause, fullscreen, pip, volume control의 프로토타입 작성
- 서랍 UI 리팩토링
- 비디오를 렌더링 하기 위한 라이브 섹션 및 라이브 컴포넌트의 프로토타입을 작성 계속 진행
