### PR TITLE
refactor: 라이브 섹션 및 라이브 영역 컴포넌트 리팩토링, pip 핸들러 개선

### DIFF
--- a/client/src/app/features/live/Live.tsx
+++ b/client/src/app/features/live/Live.tsx
@@ -8,30 +8,16 @@ import {
   type RefObject,
   forwardRef,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
 import Hls from 'hls.js';
 import clsx from 'clsx';
-import PlaySvg from '@components/svgs/PlaySvg';
-import PauseSvg from '@components/svgs/PauseSvg';
-import SoundLowSvg from '@components/svgs/SoundLowSvg';
-import SoundMutedSvg from '@components/svgs/SoundMutedSvg';
-import SoundHighSvg from '@components/svgs/SoundHighSvg';
-import VideoIconButton from './VideoIconButton';
-import FullscreenSvg from '@components/svgs/FullscreenSvg';
-import FullscreenQuitSvg from '@components/svgs/FullscreenQuitSvg';
-import PipSvg from '@components/svgs/PipSvg';
-import PipQuitSvg from '@components/svgs/PipQuitSvg';
-import { VIDEO_ICON_COMPONENT_TYPE } from '@libs/constants';
 import LiveInfo from './LiveInfo';
 import useFullscreen from '@hooks/useFullscreen';
 import usePip from '@hooks/usePip';
 import useMouseMovementOnElement from '@hooks/useMouseMovementOnElement';
 import usePlay from '@hooks/usePlay';
-import useLiveContext from '@hooks/useLiveContext';
-import LiveSvg from '@components/svgs/LiveSvg';
 import useFocused from '@hooks/useFocused';
 
 const demoHlsUrl =
@@ -121,7 +107,7 @@ const LiveController = ({ children }: Props) => {
     }
   }, []);
 
-  const isShowControls = useMemo(() => isFocusing || isMouseMoving, [isFocusing, isMouseMoving]);
+  const isShowControls = isFocusing || isMouseMoving;
 
   return children({
     volume,
@@ -180,136 +166,10 @@ const Video = forwardRef(({}: {}, ref: ForwardedRef<HTMLVideoElement>) => {
   );
 });
 
-type VideoControllersWrapperProps = PropsWithChildren<{
-  isShowControls: boolean;
-}>;
-
-const VideoControllersWrapper = ({ children, isShowControls }: VideoControllersWrapperProps) => {
-  const { isLivePage } = useLiveContext();
-  return (
-    <div
-      className={clsx(
-        'funch-overlay absolute bottom-0 left-0 right-0 top-0 px-3.5 pb-2.5 pt-3.5',
-        isShowControls ? 'opacity-100' : 'opacity-0',
-      )}
-    >
-      <div className={clsx('flex h-full w-full flex-col', isLivePage ? 'justify-between' : 'justify-end')}>
-        {isLivePage && (
-          <div className="w-full">
-            <div className="bg-surface-red-strong ml-auto flex h-6 w-14 items-center justify-center rounded-md">
-              <LiveSvg />
-            </div>
-          </div>
-        )}
-        <div className="flex h-9 items-center justify-between">{children}</div>
-      </div>
-    </div>
-  );
-};
-
-const VideoControllers = ({ children }: PropsWithChildren) => {
-  return <div className={clsx('flex items-center')}>{children}</div>;
-};
-
-const FullscreenButton = ({
-  isFullscreen,
-  startFullscreen,
-  exitFullscreen,
-}: {
-  isFullscreen: boolean;
-  startFullscreen: () => void;
-  exitFullscreen: () => void;
-}) => {
-  return (
-    <VideoIconButton
-      title={isFullscreen ? '전체화면 종료' : '전체화면 시작'}
-      aria-label={isFullscreen ? '전체화면 종료하기' : '전체화면 시작하기'}
-      onClick={() => {
-        isFullscreen ? exitFullscreen() : startFullscreen();
-      }}
-      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
-    >
-      {isFullscreen ? <FullscreenQuitSvg /> : <FullscreenSvg />}
-    </VideoIconButton>
-  );
-};
-
-const PipToggleButton = ({
-  togglePip,
-  isPip,
-  isFullscreen,
-}: {
-  togglePip: () => void;
-  isPip: boolean;
-  isFullscreen: boolean;
-}) => {
-  return (
-    <VideoIconButton
-      title="PIP 모드 전환"
-      aria-label={isPip ? 'PIP 모드 종료하기' : 'PIP 모드 시작하기'}
-      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
-      onClick={togglePip}
-    >
-      {isPip ? <PipQuitSvg /> : <PipSvg />}
-    </VideoIconButton>
-  );
-};
-
-const MuteButton = ({ toggleMute }: { toggleMute: () => void }) => {
-  return (
-    <button
-      onClick={toggleMute}
-      className="text-content-static-white inline-flex h-10 w-10 items-center justify-center"
-    >
-      <SoundMutedSvg />
-      <SoundLowSvg />
-      <SoundHighSvg />
-    </button>
-  );
-};
-
-const TogglePlayButton = ({
-  togglePlay,
-  isPlay,
-  isFullscreen,
-}: {
-  togglePlay: () => void;
-  isPlay: boolean;
-  isFullscreen: boolean;
-}) => {
-  return (
-    <VideoIconButton
-      title={isPlay ? '정지' : '재생'}
-      aria-label={isPlay ? '영상 정지하기' : '영상 재생하기'}
-      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
-      onClick={togglePlay}
-    >
-      {isPlay ? <PauseSvg /> : <PlaySvg />}
-    </VideoIconButton>
-  );
-};
-
-const VolumeController = ({
-  volume,
-  handleChangeVolume,
-}: {
-  volume: number;
-  handleChangeVolume: (e: ChangeEvent<HTMLInputElement>) => void;
-}) => {
-  return <input type="range" min="0" max="100" value={volume} onChange={handleChangeVolume} />;
-};
-
 const Live = Object.assign(LiveController, {
   Wrapper: LiveWrapper,
   VideoWrapper,
   Video,
-  VideoControllersWrapper,
-  VideoControllers,
-  Play: TogglePlayButton,
-  Fullscreen: FullscreenButton,
-  Pip: PipToggleButton,
-  Mute: MuteButton,
-  Volume: VolumeController,
   Info: LiveInfo,
 });
 

--- a/client/src/app/features/live/Live.tsx
+++ b/client/src/app/features/live/Live.tsx
@@ -37,25 +37,27 @@ import useFocused from '@hooks/useFocused';
 const demoHlsUrl =
   'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
 
-const LiveController = ({
-  children,
-}: {
-  children: (args: {
-    volume: number;
-    videoRef: RefObject<HTMLVideoElement>;
-    videoWrapperRef: RefObject<HTMLDivElement>;
-    isShowControls: boolean;
-    isPip: boolean;
-    isPlay: boolean;
-    togglePlay: () => void;
-    togglePip: () => void;
-    isFullscreen: boolean;
-    startFullscreen: () => void;
-    exitFullscreen: () => void;
-    toggleMute: () => void;
-    handleChangeVolume: (e: ChangeEvent<HTMLInputElement>) => void;
-  }) => ReactNode;
-}) => {
+type ChildrenArgs = {
+  volume: number;
+  videoRef: RefObject<HTMLVideoElement>;
+  videoWrapperRef: RefObject<HTMLDivElement>;
+  isShowControls: boolean;
+  isPip: boolean;
+  isPlay: boolean;
+  togglePlay: () => void;
+  togglePip: () => void;
+  isFullscreen: boolean;
+  startFullscreen: () => void;
+  exitFullscreen: () => void;
+  toggleMute: () => void;
+  handleChangeVolume: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+type Props = {
+  children: (args: ChildrenArgs) => ReactNode;
+};
+
+const LiveController = ({ children }: Props) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const [volume, setVolume] = useState(50);
@@ -138,14 +140,27 @@ const LiveController = ({
   });
 };
 
+const LiveWrapper = ({ children }: PropsWithChildren) => {
+  return <div className="funch-scrollable bg-bg-weak w-full">{children}</div>;
+};
+
 type VideoWrapperProps = PropsWithChildren<{
   isShowControls: boolean;
+  isFullscreen: boolean;
 }>;
 
 const VideoWrapper = forwardRef(
-  ({ children, isShowControls }: VideoWrapperProps, ref: ForwardedRef<HTMLDivElement>) => {
+  ({ children, isShowControls, isFullscreen }: VideoWrapperProps, ref: ForwardedRef<HTMLDivElement>) => {
     return (
-      <div className={clsx('w-full', isShowControls ? 'cursor-auto' : 'cursor-none')} ref={ref}>
+      <div
+        className={clsx('w-full', {
+          'flex items-center': isFullscreen,
+        })}
+        style={{
+          cursor: isShowControls ? 'auto' : 'none',
+        }}
+        ref={ref}
+      >
         <div className="pb-live-aspect-ratio relative block w-full">{children}</div>
       </div>
     );
@@ -192,6 +207,10 @@ const VideoControllersWrapper = ({ children, isShowControls }: VideoControllersW
   );
 };
 
+const VideoControllers = ({ children }: PropsWithChildren) => {
+  return <div className={clsx('flex items-center')}>{children}</div>;
+};
+
 const FullscreenButton = ({
   isFullscreen,
   startFullscreen,
@@ -203,6 +222,8 @@ const FullscreenButton = ({
 }) => {
   return (
     <VideoIconButton
+      title={isFullscreen ? '전체화면 종료' : '전체화면 시작'}
+      aria-label={isFullscreen ? '전체화면 종료하기' : '전체화면 시작하기'}
       onClick={() => {
         isFullscreen ? exitFullscreen() : startFullscreen();
       }}
@@ -224,6 +245,8 @@ const PipToggleButton = ({
 }) => {
   return (
     <VideoIconButton
+      title="PIP 모드 전환"
+      aria-label={isPip ? 'PIP 모드 종료하기' : 'PIP 모드 시작하기'}
       componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
       onClick={togglePip}
     >
@@ -256,6 +279,8 @@ const TogglePlayButton = ({
 }) => {
   return (
     <VideoIconButton
+      title={isPlay ? '정지' : '재생'}
+      aria-label={isPlay ? '영상 정지하기' : '영상 재생하기'}
       componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
       onClick={togglePlay}
     >
@@ -275,9 +300,11 @@ const VolumeController = ({
 };
 
 const Live = Object.assign(LiveController, {
+  Wrapper: LiveWrapper,
   VideoWrapper,
   Video,
   VideoControllersWrapper,
+  VideoControllers,
   Play: TogglePlayButton,
   Fullscreen: FullscreenButton,
   Pip: PipToggleButton,

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -8,6 +8,7 @@ import useLiveContext from '@hooks/useLiveContext';
 import NoLiveContent from './NoLiveContent';
 import clsx from 'clsx';
 import { type PropsWithChildren } from 'react';
+import VideoController from './VideoController';
 
 const LiveSection = () => {
   const { isLivePage, liveId } = useLiveContext();
@@ -71,23 +72,34 @@ const LiveSection = () => {
           <Live.Wrapper>
             <Live.VideoWrapper ref={videoWrapperRef} isShowControls={isShowControls} isFullscreen={isFullscreen}>
               <Live.Video ref={videoRef} />
-              <Live.VideoControllersWrapper isShowControls={isShowControls}>
-                <Live.VideoControllers>
-                  <Live.Play isFullscreen={isFullscreen} togglePlay={togglePlay} isPlay={isPlay} />
-                  <Live.Mute toggleMute={toggleMute} />
-                  <Live.Volume volume={volume} handleChangeVolume={handleChangeVolume} />
-                </Live.VideoControllers>
-                {isLivePage && (
-                  <Live.VideoControllers>
-                    <Live.Pip togglePip={togglePip} isFullscreen={isFullscreen} isPip={isPip} />
-                    <Live.Fullscreen
-                      isFullscreen={isFullscreen}
-                      startFullscreen={startFullscreen}
-                      exitFullscreen={exitFullscreen}
-                    />
-                  </Live.VideoControllers>
-                )}
-              </Live.VideoControllersWrapper>
+              <VideoController
+                value={{
+                  isFullscreen,
+                  volume,
+                  isPip,
+                  isPlay,
+                  startFullscreen,
+                  exitFullscreen,
+                  togglePip,
+                  togglePlay,
+                  toggleMute,
+                  handleChangeVolume,
+                }}
+              >
+                <VideoController.Wrapper isShowControls={isShowControls}>
+                  <VideoController.Box>
+                    <VideoController.Play />
+                    <VideoController.Mute />
+                    <VideoController.Volume />
+                  </VideoController.Box>
+                  {isLivePage && (
+                    <VideoController.Box>
+                      <VideoController.Pip />
+                      <VideoController.Fullscreen />
+                    </VideoController.Box>
+                  )}
+                </VideoController.Wrapper>
+              </VideoController>
             </Live.VideoWrapper>
             {isLivePage && <Live.Info />}
           </Live.Wrapper>

--- a/client/src/app/features/live/LiveSection.tsx
+++ b/client/src/app/features/live/LiveSection.tsx
@@ -7,6 +7,7 @@ import Live from './Live';
 import useLiveContext from '@hooks/useLiveContext';
 import NoLiveContent from './NoLiveContent';
 import clsx from 'clsx';
+import { type PropsWithChildren } from 'react';
 
 const LiveSection = () => {
   const { isLivePage, liveId } = useLiveContext();
@@ -46,14 +47,11 @@ const LiveSection = () => {
   if (isLivePage && liveId === null) return <NoLiveContent />;
 
   return (
-    <section
-      className={clsx(isLivePage ? 'h-live-section relative w-full' : 'h-live-pip w-live-pip fixed bottom-20 right-20')}
-    >
+    <Wrapper>
       {/*
-        !isLivePage && liveId === null -> null
-
-        나머지 = children?
-      */}
+       *** !isLivePage && liveId === null -> null
+       *** 나머지 = children?
+       */}
       <Live>
         {({
           videoRef,
@@ -70,62 +68,77 @@ const LiveSection = () => {
           volume,
           handleChangeVolume,
         }) => (
-          <div className={clsx('h-full w-full', isLivePage ? 'grid grid-cols-[1fr,22rem]' : 'block')}>
-            <div className="funch-scrollable bg-bg-weak w-full">
-              <Live.VideoWrapper ref={videoWrapperRef} isShowControls={isShowControls}>
-                <Live.Video ref={videoRef} />
-                <Live.VideoControllersWrapper isShowControls={isShowControls}>
-                  <div>
-                    <Live.Play isFullscreen={isFullscreen} togglePlay={togglePlay} isPlay={isPlay} />
-                    <Live.Mute toggleMute={toggleMute} />
-                    <Live.Volume volume={volume} handleChangeVolume={handleChangeVolume} />
-                  </div>
-                  <div>
+          <Live.Wrapper>
+            <Live.VideoWrapper ref={videoWrapperRef} isShowControls={isShowControls} isFullscreen={isFullscreen}>
+              <Live.Video ref={videoRef} />
+              <Live.VideoControllersWrapper isShowControls={isShowControls}>
+                <Live.VideoControllers>
+                  <Live.Play isFullscreen={isFullscreen} togglePlay={togglePlay} isPlay={isPlay} />
+                  <Live.Mute toggleMute={toggleMute} />
+                  <Live.Volume volume={volume} handleChangeVolume={handleChangeVolume} />
+                </Live.VideoControllers>
+                {isLivePage && (
+                  <Live.VideoControllers>
                     <Live.Pip togglePip={togglePip} isFullscreen={isFullscreen} isPip={isPip} />
                     <Live.Fullscreen
                       isFullscreen={isFullscreen}
                       startFullscreen={startFullscreen}
                       exitFullscreen={exitFullscreen}
                     />
-                  </div>
-                </Live.VideoControllersWrapper>
-              </Live.VideoWrapper>
-              {isLivePage && <Live.Info />}
-            </div>
-            {isLivePage && (
-              <aside
-                className={clsx('flex h-full w-[22rem] flex-col', 'border-border-neutral-weak border-x border-solid')}
-              >
-                <div
-                  className={clsx(
-                    'flex h-11 w-full items-center justify-between border-y',
-                    'border-border-neutral-weak',
-                  )}
-                >
-                  <ChatFoldSvg />
-                  <strong className={clsx('text-content-neutral-strong')}>채팅</strong>
-                  <DottedSvg />
-                </div>
-                <div className="flex flex-1 flex-col"></div>
-                <div className="flex h-[82px] flex-col px-[10px]">
-                  <div className="h-10 w-full">
-                    <input
-                      className={clsx(
-                        'h-full w-full resize-none rounded-md border-none px-2 py-2',
-                        'bg-surface-neutral-weak',
-                      )}
-                      placeholder="채팅을 입력해주세요"
-                    />
-                  </div>
-                  <div className="flex justify-end py-1">
-                    <Button>채팅</Button>
-                  </div>
-                </div>
-              </aside>
-            )}
-          </div>
+                  </Live.VideoControllers>
+                )}
+              </Live.VideoControllersWrapper>
+            </Live.VideoWrapper>
+            {isLivePage && <Live.Info />}
+          </Live.Wrapper>
         )}
       </Live>
+      {isLivePage && (
+        <aside className={clsx('flex h-full w-[22rem] flex-col', 'border-border-neutral-weak border-x border-solid')}>
+          <div className={clsx('flex h-11 w-full items-center justify-between border-y', 'border-border-neutral-weak')}>
+            <ChatFoldSvg />
+            <strong className={clsx('text-content-neutral-primary')}>채팅</strong>
+            <DottedSvg />
+          </div>
+          <div className="flex flex-1 flex-col"></div>
+          <div className="flex h-[82px] flex-col px-[10px]">
+            <div className="h-10 w-full">
+              <input
+                className={clsx(
+                  'h-full w-full resize-none rounded-md border-none px-2 py-2',
+                  'bg-surface-neutral-weak',
+                )}
+                placeholder="채팅을 입력해주세요"
+              />
+            </div>
+            <div className="flex justify-end py-1">
+              <Button>채팅</Button>
+            </div>
+          </div>
+        </aside>
+      )}
+    </Wrapper>
+  );
+};
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  const { isLivePage } = useLiveContext();
+  return (
+    <section
+      className={clsx({
+        'h-live-section relative w-full': isLivePage,
+        'h-live-pip w-live-pip fixed bottom-20 right-20': !isLivePage,
+      })}
+    >
+      <div
+        className={clsx({
+          'h-full w-full': true,
+          'grid grid-cols-[1fr,22rem]': isLivePage,
+          block: !isLivePage,
+        })}
+      >
+        {children}
+      </div>
     </section>
   );
 };

--- a/client/src/app/features/live/VideoController.tsx
+++ b/client/src/app/features/live/VideoController.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import LiveSvg from '@components/svgs/LiveSvg';
+import useLiveContext from '@hooks/useLiveContext';
+import clsx from 'clsx';
+import { createContext, useContext, useMemo, type ChangeEvent, type PropsWithChildren } from 'react';
+import VideoIconButton from './VideoIconButton';
+import { VIDEO_ICON_COMPONENT_TYPE } from '@libs/constants';
+import FullscreenQuitSvg from '@components/svgs/FullscreenQuitSvg';
+import FullscreenSvg from '@components/svgs/FullscreenSvg';
+import PipQuitSvg from '@components/svgs/PipQuitSvg';
+import PipSvg from '@components/svgs/PipSvg';
+import SoundMutedSvg from '@components/svgs/SoundMutedSvg';
+import SoundLowSvg from '@components/svgs/SoundLowSvg';
+import SoundHighSvg from '@components/svgs/SoundHighSvg';
+import PauseSvg from '@components/svgs/PauseSvg';
+import PlaySvg from '@components/svgs/PlaySvg';
+
+type PlayContextType = {
+  isPlay: boolean;
+  togglePlay: () => void;
+};
+
+type VolumeContextType = {
+  volume: number;
+  handleChangeVolume: (e: ChangeEvent<HTMLInputElement>) => void;
+  toggleMute: () => void;
+};
+
+type PipContextType = {
+  isPip: boolean;
+  togglePip: () => void;
+};
+
+type FullscreenContextType = {
+  isFullscreen: boolean;
+  startFullscreen: () => void;
+  exitFullscreen: () => void;
+};
+
+const PlayContext = createContext<PlayContextType>({
+  isPlay: false,
+  togglePlay: () => {},
+});
+
+const VolumeContext = createContext<VolumeContextType>({
+  volume: 50,
+  handleChangeVolume: () => {},
+  toggleMute: () => {},
+});
+
+const PipContext = createContext<PipContextType>({
+  isPip: false,
+  togglePip: () => {},
+});
+
+const FullscreenContext = createContext<FullscreenContextType>({
+  isFullscreen: false,
+  startFullscreen: () => {},
+  exitFullscreen: () => {},
+});
+
+const usePlayContext = () => {
+  const { isPlay, togglePlay } = useContext(PlayContext);
+  return useMemo(() => ({ isPlay, togglePlay }), [isPlay, togglePlay]);
+};
+
+const useVolumeContext = () => {
+  const { volume, handleChangeVolume, toggleMute } = useContext(VolumeContext);
+  return useMemo(() => ({ volume, handleChangeVolume, toggleMute }), [volume, handleChangeVolume, toggleMute]);
+};
+
+const usePipContext = () => {
+  const { isPip, togglePip } = useContext(PipContext);
+  return useMemo(() => ({ isPip, togglePip }), [isPip, togglePip]);
+};
+
+const useFullscreenContext = () => {
+  const { isFullscreen, startFullscreen, exitFullscreen } = useContext(FullscreenContext);
+
+  return useMemo(
+    () => ({
+      isFullscreen,
+      startFullscreen,
+      exitFullscreen,
+    }),
+    [isFullscreen, startFullscreen, exitFullscreen],
+  );
+};
+
+type Props = PropsWithChildren<{
+  value: PlayContextType & VolumeContextType & PipContextType & FullscreenContextType;
+}>;
+
+const VideoControllerProvider = ({
+  children,
+  value: {
+    isFullscreen,
+    volume,
+    isPip,
+    isPlay,
+    startFullscreen,
+    exitFullscreen,
+    togglePip,
+    togglePlay,
+    toggleMute,
+    handleChangeVolume,
+  },
+}: Props) => {
+  return (
+    <FullscreenContext.Provider value={{ isFullscreen, startFullscreen, exitFullscreen }}>
+      <PipContext.Provider value={{ isPip, togglePip }}>
+        <VolumeContext.Provider value={{ volume, handleChangeVolume, toggleMute }}>
+          <PlayContext.Provider value={{ isPlay, togglePlay }}>{children}</PlayContext.Provider>
+        </VolumeContext.Provider>
+      </PipContext.Provider>
+    </FullscreenContext.Provider>
+  );
+};
+
+type VideoControllerWrapperProps = PropsWithChildren<{
+  isShowControls: boolean;
+}>;
+
+const VideoControllerWrapper = ({ children, isShowControls }: VideoControllerWrapperProps) => {
+  const { isLivePage } = useLiveContext();
+  return (
+    <div
+      className={clsx(
+        'funch-overlay absolute bottom-0 left-0 right-0 top-0 px-3.5 pb-2.5 pt-3.5',
+        isShowControls ? 'opacity-100' : 'opacity-0',
+      )}
+    >
+      <div className={clsx('flex h-full w-full flex-col', isLivePage ? 'justify-between' : 'justify-end')}>
+        {isLivePage && (
+          <div className="w-full">
+            <div className="bg-surface-red-strong ml-auto flex h-6 w-14 items-center justify-center rounded-md">
+              <LiveSvg />
+            </div>
+          </div>
+        )}
+        <div className="flex h-9 items-center justify-between">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+const VideoControllerBox = ({ children }: PropsWithChildren) => {
+  return <div className={clsx('flex items-center')}>{children}</div>;
+};
+
+const FullscreenButton = () => {
+  const { isFullscreen, startFullscreen, exitFullscreen } = useFullscreenContext();
+  return (
+    <VideoIconButton
+      title={isFullscreen ? '전체화면 종료' : '전체화면 시작'}
+      aria-label={isFullscreen ? '전체화면 종료하기' : '전체화면 시작하기'}
+      onClick={() => {
+        isFullscreen ? exitFullscreen() : startFullscreen();
+      }}
+      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
+    >
+      {isFullscreen ? <FullscreenQuitSvg /> : <FullscreenSvg />}
+    </VideoIconButton>
+  );
+};
+
+const PipButton = () => {
+  const { togglePip, isPip } = usePipContext();
+  const { isFullscreen } = useFullscreenContext();
+  return (
+    <VideoIconButton
+      title="PIP 모드 전환"
+      aria-label={isPip ? 'PIP 모드 종료하기' : 'PIP 모드 시작하기'}
+      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
+      onClick={togglePip}
+    >
+      {isPip ? <PipQuitSvg /> : <PipSvg />}
+    </VideoIconButton>
+  );
+};
+
+const MuteButton = () => {
+  const { toggleMute } = useVolumeContext();
+  return (
+    <button
+      onClick={toggleMute}
+      className="text-content-static-white inline-flex h-10 w-10 items-center justify-center"
+    >
+      <SoundMutedSvg />
+      <SoundLowSvg />
+      <SoundHighSvg />
+    </button>
+  );
+};
+
+const PlayButton = () => {
+  const { togglePlay, isPlay } = usePlayContext();
+  const { isFullscreen } = useFullscreenContext();
+  return (
+    <VideoIconButton
+      title={isPlay ? '정지' : '재생'}
+      aria-label={isPlay ? '영상 정지하기' : '영상 재생하기'}
+      componentType={isFullscreen ? VIDEO_ICON_COMPONENT_TYPE.FULLSCREEN : VIDEO_ICON_COMPONENT_TYPE.DEFAULT}
+      onClick={togglePlay}
+    >
+      {isPlay ? <PauseSvg /> : <PlaySvg />}
+    </VideoIconButton>
+  );
+};
+
+const VolumeController = () => {
+  const { volume, handleChangeVolume } = useVolumeContext();
+  return <input type="range" min="0" max="100" value={volume} onChange={handleChangeVolume} />;
+};
+
+const VideoController = Object.assign(VideoControllerProvider, {
+  Wrapper: VideoControllerWrapper,
+  Box: VideoControllerBox,
+  Fullscreen: FullscreenButton,
+  Pip: PipButton,
+  Mute: MuteButton,
+  Play: PlayButton,
+  Volume: VolumeController,
+});
+
+export default VideoController;

--- a/client/src/app/hooks/useMouseMovementOnElement.ts
+++ b/client/src/app/hooks/useMouseMovementOnElement.ts
@@ -19,6 +19,9 @@ const useMouseMovementOnElement = (ref: RefObject<HTMLElement>) => {
       clearTimeout(timerRef.current);
     }
     setIsMouseMoving(false);
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
   };
 
   useEffect(() => {

--- a/client/src/app/hooks/usePip.ts
+++ b/client/src/app/hooks/usePip.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useState } from 'react';
+import { type RefObject, useEffect, useState } from 'react';
 
 const usePip = (ref: RefObject<HTMLVideoElement>) => {
   const [isPip, setIsPip] = useState(false);
@@ -6,14 +6,35 @@ const usePip = (ref: RefObject<HTMLVideoElement>) => {
   const togglePip = () => {
     if (document.pictureInPictureElement) {
       document.exitPictureInPicture();
-      setIsPip(false);
     } else {
       if (ref.current && ref.current.requestPictureInPicture) {
         ref.current.requestPictureInPicture();
-        setIsPip(true);
       }
     }
   };
+
+  useEffect(() => {
+    const handleEnterPip = () => {
+      if (document.pictureInPictureElement) {
+        setIsPip(true);
+      }
+    };
+    const handleLeavePip = () => {
+      if (!document.pictureInPictureElement) {
+        setIsPip(false);
+      }
+    };
+    if (ref.current) {
+      ref.current.addEventListener('enterpictureinpicture', handleEnterPip);
+      ref.current.addEventListener('leavepictureinpicture', handleLeavePip);
+    }
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('enterpictureinpicture', handleEnterPip);
+        ref.current.removeEventListener('leavepictureinpicture', handleLeavePip);
+      }
+    };
+  }, []);
 
   return { isPip, togglePip };
 };

--- a/client/src/app/hooks/usePlay.ts
+++ b/client/src/app/hooks/usePlay.ts
@@ -1,17 +1,35 @@
-import { type RefObject, useState } from 'react';
+import { type RefObject, useEffect, useState } from 'react';
 
 const usePlay = (ref: RefObject<HTMLVideoElement>) => {
   const [isPlay, setIsPlay] = useState(true);
 
   const togglePlay = () => {
-    if (ref.current && ref.current.paused) {
+    if (!ref.current) return;
+    if (ref.current.paused) {
       ref.current.play();
-      setIsPlay(true);
     } else {
-      ref.current?.pause();
-      setIsPlay(false);
+      ref.current.pause();
     }
   };
+
+  useEffect(() => {
+    const handlePlay = () => {
+      setIsPlay(true);
+    };
+    const handlePause = () => {
+      setIsPlay(false);
+    };
+    if (ref.current) {
+      ref.current.addEventListener('play', handlePlay);
+      ref.current.addEventListener('pause', handlePause);
+    }
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('play', handlePlay);
+        ref.current.removeEventListener('pause', handlePause);
+      }
+    };
+  }, []);
 
   return { isPlay, togglePlay };
 };

--- a/client/src/app/hooks/useThemeContext.ts
+++ b/client/src/app/hooks/useThemeContext.ts
@@ -5,7 +5,7 @@ const useTheme = () => {
   const context = useContext(ThemeContext);
 
   if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider');
+    throw new Error('컨텍스트가 초기화되지 않았습니다.');
   }
 
   return context;

--- a/client/src/app/libs/constants.ts
+++ b/client/src/app/libs/constants.ts
@@ -1,4 +1,4 @@
-export const appTheme = {
+export const APP_THEME = {
   LIGHT: 'LIGHT' as const,
   DARK: 'DARK' as const,
 };

--- a/client/src/app/libs/internalTypes.ts
+++ b/client/src/app/libs/internalTypes.ts
@@ -1,4 +1,4 @@
-import { appTheme, VIDEO_ICON_COMPONENT_TYPE } from '@libs/constants';
+import { APP_THEME, VIDEO_ICON_COMPONENT_TYPE } from '@libs/constants';
 
 export type SvgComponentProps = {
   svgTitle?: string;
@@ -25,6 +25,6 @@ export type Follow = {
   id: string;
 };
 
-export type AppTheme = keyof typeof appTheme;
+export type AppTheme = keyof typeof APP_THEME;
 
 export type VideoIconComponentType = keyof typeof VIDEO_ICON_COMPONENT_TYPE;

--- a/client/src/app/providers/ThemeProvider.tsx
+++ b/client/src/app/providers/ThemeProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useEffect, useState, type PropsWithChildren } from 'react';
 import type { AppTheme } from '@libs/internalTypes';
-import { appTheme, LOCAL_STORAGE_THEME_KEY } from '@libs/constants';
+import { APP_THEME, LOCAL_STORAGE_THEME_KEY } from '@libs/constants';
 
 type ThemeContextType = {
   theme: AppTheme;
@@ -12,7 +12,7 @@ type ThemeContextType = {
 };
 
 export const ThemeContext = createContext<ThemeContextType>({
-  theme: appTheme.LIGHT,
+  theme: APP_THEME.LIGHT,
   toggleTheme: () => {},
   setLightTheme: () => {},
   setDarkTheme: () => {},
@@ -21,30 +21,30 @@ export const ThemeContext = createContext<ThemeContextType>({
 type Props = PropsWithChildren;
 
 const ThemeProvider = ({ children }: Props) => {
-  const [theme, setTheme] = useState<AppTheme>(appTheme.LIGHT);
+  const [theme, setTheme] = useState<AppTheme>(APP_THEME.LIGHT);
 
   const toggleTheme = () => {
-    if (localStorage.getItem(LOCAL_STORAGE_THEME_KEY) === appTheme.DARK) {
-      localStorage.setItem(LOCAL_STORAGE_THEME_KEY, appTheme.LIGHT);
+    if (localStorage.getItem(LOCAL_STORAGE_THEME_KEY) === APP_THEME.DARK) {
+      localStorage.setItem(LOCAL_STORAGE_THEME_KEY, APP_THEME.LIGHT);
     } else {
-      localStorage.setItem(LOCAL_STORAGE_THEME_KEY, appTheme.DARK);
+      localStorage.setItem(LOCAL_STORAGE_THEME_KEY, APP_THEME.DARK);
     }
-    setTheme((prevTheme) => (prevTheme === appTheme.LIGHT ? appTheme.DARK : appTheme.LIGHT));
+    setTheme((prevTheme) => (prevTheme === APP_THEME.LIGHT ? APP_THEME.DARK : APP_THEME.LIGHT));
   };
 
   const setLightTheme = () => {
-    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, appTheme.LIGHT);
-    setTheme(appTheme.LIGHT);
+    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, APP_THEME.LIGHT);
+    setTheme(APP_THEME.LIGHT);
   };
 
   const setDarkTheme = () => {
-    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, appTheme.DARK);
-    setTheme(appTheme.DARK);
+    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, APP_THEME.DARK);
+    setTheme(APP_THEME.DARK);
   };
 
   useEffect(() => {
     if (
-      localStorage.theme === appTheme.DARK ||
+      localStorage.theme === APP_THEME.DARK ||
       (!(LOCAL_STORAGE_THEME_KEY in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
     ) {
       setDarkTheme();
@@ -54,7 +54,7 @@ const ThemeProvider = ({ children }: Props) => {
   }, []);
 
   useEffect(() => {
-    if (theme === appTheme.DARK) {
+    if (theme === APP_THEME.DARK) {
       document.documentElement.classList.add('dark');
     } else {
       document.documentElement.classList.remove('dark');


### PR DESCRIPTION
## Issue

- [x] #104 


<br><br>

## Detail

- 라이브 섹션 레이아웃 구체화 및 분리
- 컨트롤러 버튼 ARIA 및 title 속성 추가
- 타입 선언 분리 및 컨벤션 맞추기
- 웹에서 제공하는 pip 종료 버튼을 핸들링하기 위해 enterpictureinpicture, leavepictureinpicture 이벤트를 핸들링하는 이팩트를 usePip에 추가
- 비디오 컨트롤러 부분을 라이브 파일로부터 분리했다.