### PR TITLE
chore: 서버 타입(v0.1.0) 반영 및 msw 테스트 일부 작성

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -6,6 +6,10 @@ const nextConfig = {
         source: '/lives',
         destination: '/',
       },
+      {
+        source: '/api/:path*',
+        destination: process.env.NODE_ENV !== 'production' ? '/api/:path*' : 'https://api.example.com/:path*',
+      },
     ];
   },
   images: {

--- a/client/src/__mocks__/broadcasts.ts
+++ b/client/src/__mocks__/broadcasts.ts
@@ -1,0 +1,49 @@
+import type { Broadcast } from '@libs/internalTypes';
+
+export const mockedBroadcasts: Broadcast[] = [
+  {
+    broadcastId: 'aaa',
+    title: '[충격] 트럼프 당선',
+    contentCategory: 'POLITICS',
+    moodCategory: 'INTERESTING',
+    tags: ['politics', 'election'],
+    thumbnailUrl: 'https://via.placeholder.com/150',
+    viewerCount: 1000,
+  },
+  {
+    broadcastId: 'bbb',
+    title: '[데모 공유] 팀 무지개 치즈 3주차 발표',
+    contentCategory: 'TECH',
+    tags: ['funch', 'boostcamp'],
+    moodCategory: 'FUN',
+    thumbnailUrl: 'https://via.placeholder.com/150',
+    viewerCount: 100,
+  },
+  {
+    broadcastId: 'ccc',
+    title: '고양이 냥냥이 냥냥냥이',
+    contentCategory: 'ANIMAL',
+    moodCategory: 'HAPPY',
+    tags: ['cat', 'cute'],
+    thumbnailUrl: 'https://via.placeholder.com/150',
+    viewerCount: 300,
+  },
+  {
+    broadcastId: 'ddd',
+    title: '방송 제목',
+    contentCategory: 'CATEGORY',
+    moodCategory: 'MOOD',
+    tags: ['tag1', 'tag2'],
+    thumbnailUrl: 'https://via.placeholder.com/150',
+    viewerCount: 200,
+  },
+  {
+    broadcastId: 'eee',
+    title: '방송 제목',
+    contentCategory: 'CATEGORY',
+    moodCategory: 'MOOD',
+    tags: ['tag1', 'tag2'],
+    thumbnailUrl: 'https://via.placeholder.com/150',
+    viewerCount: 300,
+  },
+];

--- a/client/src/__mocks__/users.ts
+++ b/client/src/__mocks__/users.ts
@@ -1,0 +1,39 @@
+import type { User } from '@libs/internalTypes';
+
+export const mockedUsers: User[] = [
+  {
+    name: '슈카월드',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    broadcastId: 'aaa',
+    followerCount: 3211,
+    isLive: true,
+  },
+  {
+    name: '짜왕',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    broadcastId: 'bbb',
+    followerCount: 1234,
+    isLive: true,
+  },
+  {
+    name: '모카',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    broadcastId: 'ccc',
+    followerCount: 4321,
+    isLive: true,
+  },
+  {
+    name: '토끼',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    broadcastId: 'ddd',
+    followerCount: 5678,
+    isLive: true,
+  },
+  {
+    name: '펭수',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    broadcastId: 'eee',
+    followerCount: 8765,
+    isLive: true,
+  },
+];

--- a/client/src/__test__/msw.test.ts
+++ b/client/src/__test__/msw.test.ts
@@ -1,0 +1,17 @@
+import { mockedBroadcasts } from '@mocks/broadcasts';
+import { mockedUsers } from '@mocks/users';
+import { describe, expect, test } from 'vitest';
+
+describe('msw handlers', () => {
+  test('should return mocked broadcasts', async () => {
+    const response = await fetch('/api/broadcasts');
+    const data = await response.json();
+    expect(data).toStrictEqual(mockedBroadcasts);
+  });
+  test('should return user by broadcastId', async () => {
+    const mockedUser = mockedUsers[0];
+    const response = await fetch(`/api/users/${mockedUser.broadcastId}`);
+    const data = await response.json();
+    expect(data).toStrictEqual(mockedUser);
+  });
+});

--- a/client/src/__test__/msw.test.ts
+++ b/client/src/__test__/msw.test.ts
@@ -3,6 +3,11 @@ import { mockedUsers } from '@mocks/users';
 import { describe, expect, test } from 'vitest';
 
 describe('msw handlers', () => {
+  test('should return pong', async () => {
+    const response = await fetch('/api/ping');
+    const data = await response.json();
+    expect(data).toBe('pong');
+  });
   test('should return mocked broadcasts', async () => {
     const response = await fetch('/api/broadcasts');
     const data = await response.json();

--- a/client/src/__test__/sum.test.ts
+++ b/client/src/__test__/sum.test.ts
@@ -1,9 +1,0 @@
-import { expect, test } from 'vitest';
-
-const sum = (a: number, b: number) => {
-  return a + b;
-};
-
-test('first', () => {
-  expect(sum(1, 2)).toBe(3);
-});

--- a/client/src/app/(domain)/features/RecommendedLives.tsx
+++ b/client/src/app/(domain)/features/RecommendedLives.tsx
@@ -3,21 +3,40 @@
 import DeemedLink from '@components/DeemedLink';
 import clsx from 'clsx';
 import Lives from '@components/livesGrid/Lives';
-import { mockedLives } from '@mocks/lives';
+import { useEffect, useState } from 'react';
+import type { Broadcast } from '@libs/internalTypes';
 
 const RecommendedLives = () => {
+  const [lives, setLives] = useState<Broadcast[]>([]);
+
+  useEffect(() => {
+    let isValidEffect = true;
+    const fetchLives = async () => {
+      const response = await fetch('/api/broadcasts');
+      const data = await response.json();
+      if (!isValidEffect) return;
+      setLives(data);
+    };
+
+    fetchLives();
+
+    return () => {
+      isValidEffect = false;
+    };
+  }, []);
+
   return (
     <div>
       <div className={clsx('mb-2 flex items-center justify-between')}>
         <h2 className={clsx('text-content-neutral-primary funch-bold20')}>이 방송 어때요?</h2>
         <DeemedLink url="/" name="전체보기" />
       </div>
-      <Lives lives={mockedLives}>
+      <Lives lives={lives}>
         {({ visibleLives, isExpanded, toggle }) => (
           <>
             <Lives.List>
               {visibleLives.map((live) => (
-                <Lives.Live key={live.id} live={live} />
+                <Lives.Live key={live.broadcastId} live={live} />
               ))}
             </Lives.List>
             <Lives.Expand isExpanded={isExpanded} toggle={toggle} />

--- a/client/src/libs/internalTypes.ts
+++ b/client/src/libs/internalTypes.ts
@@ -28,3 +28,35 @@ export type Follow = {
 export type AppTheme = keyof typeof APP_THEME;
 
 export type VideoIconComponentType = keyof typeof VIDEO_ICON_COMPONENT_TYPE;
+
+// API models
+export type Broadcast = {
+  broadcastId: string;
+  title: string;
+  contentCategory: string;
+  moodCategory: string;
+  tags: string[];
+  thumbnailUrl: string;
+  viewerCount: number;
+};
+
+export type Playlist = {
+  url: string;
+};
+
+export type Streamkey = {
+  id: string;
+};
+
+export type Token = {
+  accessToken: string;
+  refreshToken?: string;
+};
+
+export type User = {
+  name: string;
+  profileImageUrl: string;
+  broadcastId: string;
+  followerCount: number;
+  isLive: boolean;
+};

--- a/client/src/server/handlers.ts
+++ b/client/src/server/handlers.ts
@@ -2,6 +2,10 @@ import { mockedBroadcasts } from '@mocks/broadcasts';
 import { mockedUsers } from '@mocks/users';
 import { http, HttpResponse } from 'msw';
 
+const ping = () => {
+  return HttpResponse.json('pong');
+};
+
 const getBroadcasts = () => {
   return HttpResponse.json(mockedBroadcasts);
 };
@@ -12,6 +16,7 @@ const getUserByBroadcastId = ({ params }: { params: { broadcastId: string } }) =
 };
 
 export const handlers = [
+  http.get('/api/ping', ping),
   http.get('/api/broadcasts', getBroadcasts),
   http.get('/api/users/:broadcastId', getUserByBroadcastId),
 ];

--- a/client/src/server/handlers.ts
+++ b/client/src/server/handlers.ts
@@ -1,7 +1,17 @@
+import { mockedBroadcasts } from '@mocks/broadcasts';
+import { mockedUsers } from '@mocks/users';
 import { http, HttpResponse } from 'msw';
 
+const getBroadcasts = () => {
+  return HttpResponse.json(mockedBroadcasts);
+};
+
+const getUserByBroadcastId = ({ params }: { params: { broadcastId: string } }) => {
+  const user = mockedUsers.find((user) => user.broadcastId === params.broadcastId);
+  return HttpResponse.json(user);
+};
+
 export const handlers = [
-  http.get('/api/ping', () => {
-    return HttpResponse.json('pong');
-  }),
+  http.get('/api/broadcasts', getBroadcasts),
+  http.get('/api/users/:broadcastId', getUserByBroadcastId),
 ];

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -7,7 +7,7 @@ dotenv.config({
 });
 
 beforeAll(async () => {
-  const { server } = await import('./src/app/server/node');
+  const { server } = await import('@server/node');
   server.listen();
 });
 


### PR DESCRIPTION
- `/api/:path*`에 대한 요청을 production인 경우 `https://api.example.com/:path\*`로 rewrite하도록 next.config.mjs 임시 수정
- Broadcast, Playlist, Streamkey, Token, User 타입 선언 (internalTypes.ts)
- broadcast, user에 대한 목 데이터 생성 (mockedBroadcasts, mockedUsers)
- msw 핸들러 추가 (getBroadcasts, getUserByBroadcastId)
- msw 핸들러 테스트 코드 추가