### PR TITLE
클라이언트 live playlist 요청에 따른 응답 API 구현

### DIFF
--- a/applicationServer/package-lock.json
+++ b/applicationServer/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "aplicationServer",
+  "name": "applicationServer",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,6 +7,7 @@
       "dependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.0.0",
         "dotenv": "^16.4.5",
         "mysql2": "^3.11.4",
@@ -1483,6 +1484,26 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }

--- a/applicationServer/package.json
+++ b/applicationServer/package.json
@@ -47,7 +47,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": "",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -56,6 +56,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@live/(.*)$": "<rootDir>/src/live/$1"
+    }
   }
 }

--- a/applicationServer/package.json
+++ b/applicationServer/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "dotenv": "^16.4.5",
     "mysql2": "^3.11.4",

--- a/applicationServer/src/app.module.ts
+++ b/applicationServer/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { MemberModule } from './member/member.module';
+import { LiveModule } from './live/live.module';
 
 @Module({
-  imports: [MemberModule],
+  imports: [MemberModule, LiveModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/applicationServer/src/live/entities/live.entity.ts
+++ b/applicationServer/src/live/entities/live.entity.ts
@@ -1,0 +1,15 @@
+import { Broadcast } from '@src/types'
+
+class Live {
+    public data: Map<string, Broadcast>;
+    private static instance: Live;
+    private constructor() {
+        this.data = new Map();
+    }
+
+    public static getInstance() {
+        return this.instance != null ? this.instance : this.instance = new Live();
+    }
+}
+
+export { Live }

--- a/applicationServer/src/live/live.controller.ts
+++ b/applicationServer/src/live/live.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { LiveService } from '@live/live.service';
+
+@Controller('live')
+export class LiveController {
+  constructor(private readonly liveService: LiveService) {}
+
+  @Get(':broadcastId')
+  getPlaylistUrl(@Param('broadcastId') broadcastId: string) {
+    return this.liveService.responsePlaylistUrl(broadcastId);
+  }
+}

--- a/applicationServer/src/live/live.module.ts
+++ b/applicationServer/src/live/live.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { LiveService } from './live.service';
+import { LiveController } from './live.controller';
+
+@Module({
+  controllers: [LiveController],
+  providers: [LiveService],
+})
+export class LiveModule {}

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -17,6 +17,9 @@ export class LiveService {
       return playlist;
     } else {
       throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
-    }
+if(!this.live.data.has(broadcastId)) throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+
+const playlist: Playlist = { url: createMultivariantPlaylistUrl(broadcastId) }
+return playlist;
   }
 }

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, HttpException, HttpStatus} from '@nestjs/common';
+import { Live } from '@live/entities/live.entity';
+import { Playlist } from '@src/types'
+
+@Injectable()
+export class LiveService {
+  live: Live
+  constructor() {
+    this.live = Live.getInstance();
+  }
+
+  responsePlaylistUrl(broadcastId) {
+    const createMultivariantPlaylistUrl = (id) =>  `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
+    
+    if(this.live.data.has(broadcastId)) {
+      const playlist: Playlist = { url: createMultivariantPlaylistUrl(broadcastId) }
+      return playlist;
+    } else {
+      throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+    }
+  }
+}

--- a/applicationServer/test/live/live.service.spec.ts
+++ b/applicationServer/test/live/live.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LiveService } from '@live/live.service';
+import { Live } from '@live/entities/live.entity';
+import { Broadcast } from '@src/types'
+
+describe('LiveService 테스트', () => {
+  let service: LiveService;
+
+  const mockBroadcastData: Broadcast = {
+    broadcastId: 'test',
+    title: 'title',
+    contentCategory: 'content',
+    moodCategory: 'mood',
+    tags: [],
+    thumbnailUrl: 'thumbnail',
+    viewerCount: 24
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LiveService],
+    }).compile();
+    service = module.get<LiveService>(LiveService);
+  });
+
+  it('LiveService가 정의되어 있어야 한다.', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('생방송 중인 스트리머의 broadcast Id로 playlist를 요청하면 playlist url이 담긴 객체를 반환해야 한다.' , () => {
+    const live: Live = Live.getInstance();
+    live.data.set('test', mockBroadcastData);
+
+    const result = service.responsePlaylistUrl('test')
+    const createMultivariantPlaylistUrl = (id) =>  `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
+    
+    expect(result.url).toEqual(createMultivariantPlaylistUrl('test'));
+  });
+
+  it('오프라인 스트리머의 broadcast Id로 playlist를 요청하면 에러가 발생해야 한다.', () => {
+    expect(()=> {service.responsePlaylistUrl('no user')}).toThrow();
+  })
+});

--- a/applicationServer/tsconfig.json
+++ b/applicationServer/tsconfig.json
@@ -15,7 +15,8 @@
       "@src/*": ["src/*"],
       "@auth/*": ["src/database/*"],
       "@database/*": ["src/database/*"],
-      "@member/*": ["src/member/*"]
+      "@member/*": ["src/member/*"],
+      "@live/*": ["src/live/*"]
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Issue

- [x] #202 


<br><br>

## Detail

- Application Server에서 방송 정보를 전역적으로 메모리에서 관리하기 위해 Live Entity를 생성했습니다.
- 특정 broadcastId를 `live/:broadcastId`로 전달 시 생방송 중인지 확인해 결과 값을 달리 반환하는 모듈을 작성하였습니다.
- service 로직에 대한 테스트 코드를 `application/test` 디렉토리에 작성했습니다.