### PR TITLE
전체 및 추천 방송 목록 전달

### DIFF
--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -1,3 +1,6 @@
 // member.providers.ts
 export const MEMBER_REPOSITORY = 'MEMBER_REPOSITORY';
 export const DATA_SOURCE = 'DATA_SOURCE';
+
+// live.controller.ts
+export const SUGGEST_LIVE_COUNT = 10;

--- a/applicationServer/src/live/live.controller.ts
+++ b/applicationServer/src/live/live.controller.ts
@@ -1,12 +1,23 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { LiveService } from '@live/live.service';
+import { SUGGEST_LIVE_COUNT } from '@src/constants';
 
 @Controller('live')
 export class LiveController {
   constructor(private readonly liveService: LiveService) {}
 
+  @Get('/list')
+  getLivelistAlignViewerCount(@Query('start') start: number, @Query('end') end: number) {
+    return this.liveService.getLiveList(start, end);
+  }
+
   @Get(':broadcastId')
   getPlaylistUrl(@Param('broadcastId') broadcastId: string) {
     return this.liveService.responsePlaylistUrl(broadcastId);
+  }
+
+  @Get('/list/suggest')
+  getSuggestLiveList() {
+    return { suggest: this.liveService.getCurrentLiveListRandomShuffle(SUGGEST_LIVE_COUNT) };
   }
 }

--- a/applicationServer/src/live/live.module.ts
+++ b/applicationServer/src/live/live.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { LiveService } from './live.service';
-import { LiveController } from './live.controller';
+import { LiveService } from '@live/live.service';
+import { LiveController } from '@live/live.controller';
 
 @Module({
   controllers: [LiveController],

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -1,25 +1,44 @@
-import { Injectable, HttpException, HttpStatus} from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { Live } from '@live/entities/live.entity';
-import { Playlist } from '@src/types'
+import { Broadcast, Playlist } from '@src/types';
 
 @Injectable()
 export class LiveService {
-  live: Live
+  live: Live;
   constructor() {
     this.live = Live.getInstance();
   }
 
-  responsePlaylistUrl(broadcastId) {
-    const createMultivariantPlaylistUrl = (id) =>  `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
-    
-    if(this.live.data.has(broadcastId)) {
-      const playlist: Playlist = { url: createMultivariantPlaylistUrl(broadcastId) }
-      return playlist;
-    } else {
-      throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
-if(!this.live.data.has(broadcastId)) throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+  getLiveList(start, end) {
+    const alignLiveList = Array.from(this.live.data.values()).sort((a, b) => b.viewerCount - a.viewerCount);
+    return alignLiveList.slice(start, end ?? alignLiveList.length);
+  }
 
-const playlist: Playlist = { url: createMultivariantPlaylistUrl(broadcastId) }
-return playlist;
+  responsePlaylistUrl(broadcastId) {
+    const createMultivariantPlaylistUrl = (id) =>
+      `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
+
+    if (!this.live.data.has(broadcastId)) throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+
+    const playlist: Playlist = { url: createMultivariantPlaylistUrl(broadcastId) };
+    return playlist;
+  }
+
+  getCurrentLiveListRandomShuffle(count) {
+    const allLives = Array.from(this.live.data.values());
+    if (allLives.length <= count) return allLives;
+
+    const result: Broadcast[] = [];
+    while (result.length < count) {
+      const history = {};
+      const randomCount = Math.floor(allLives.length * Math.random());
+
+      if (!history[randomCount]) {
+        result.push(allLives[randomCount]);
+        history[randomCount] = true;
+      }
+    }
+
+    return result;
   }
 }

--- a/applicationServer/test/live/live.service.spec.ts
+++ b/applicationServer/test/live/live.service.spec.ts
@@ -1,7 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LiveService } from '@live/live.service';
 import { Live } from '@live/entities/live.entity';
-import { Broadcast } from '@src/types'
+import { Broadcast } from '@src/types';
+
+function getMockLiveDataList(count) {
+  const dummy = new Array(count).fill(0);
+  const result: Broadcast[] = dummy.map((e, i) => {
+    return {
+      broadcastId: `test${i}`,
+      title: `title${i}`,
+      contentCategory: `content${i}`,
+      moodCategory: `mood${i}`,
+      tags: [`i${i}`],
+      thumbnailUrl: `http://thumbnail${i}`,
+      viewerCount: Math.ceil((i + 1000) * Math.random()),
+    };
+  });
+
+  return result;
+}
 
 describe('LiveService 테스트', () => {
   let service: LiveService;
@@ -13,8 +30,8 @@ describe('LiveService 테스트', () => {
     moodCategory: 'mood',
     tags: [],
     thumbnailUrl: 'thumbnail',
-    viewerCount: 24
-  }
+    viewerCount: 24,
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -27,17 +44,44 @@ describe('LiveService 테스트', () => {
     expect(service).toBeDefined();
   });
 
-  it('생방송 중인 스트리머의 broadcast Id로 playlist를 요청하면 playlist url이 담긴 객체를 반환해야 한다.' , () => {
+  it('생방송 중인 스트리머의 broadcast Id로 playlist를 요청하면 playlist url이 담긴 객체를 반환해야 한다.', () => {
     const live: Live = Live.getInstance();
     live.data.set('test', mockBroadcastData);
 
-    const result = service.responsePlaylistUrl('test')
-    const createMultivariantPlaylistUrl = (id) =>  `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
-    
+    const result = service.responsePlaylistUrl('test');
+    const createMultivariantPlaylistUrl = (id) =>
+      `https://kr.object.ncloudstorage.com/media-storage/${id}/master_playlist.m3u8`;
+
     expect(result.url).toEqual(createMultivariantPlaylistUrl('test'));
+    live.data.clear();
   });
 
   it('오프라인 스트리머의 broadcast Id로 playlist를 요청하면 에러가 발생해야 한다.', () => {
-    expect(()=> {service.responsePlaylistUrl('no user')}).toThrow();
-  })
+    expect(() => {
+      service.responsePlaylistUrl('no user');
+    }).toThrow();
+  });
+
+  it('생방송 중인 스트리머 리스트를 정해진 개수만큼 랜덤으로 받아와야 한다.', () => {
+    const liveCount = 10;
+    const live: Live = Live.getInstance();
+    getMockLiveDataList(liveCount * 3).forEach((mockData) => live.data.set(mockData.broadcastId, mockData));
+
+    const testList1 = service.getCurrentLiveListRandomShuffle(liveCount);
+    const testList2 = service.getCurrentLiveListRandomShuffle(liveCount);
+
+    expect(testList1).not.toEqual(testList2);
+    live.data.clear();
+  });
+
+  it('생방송 중인 스트리머 리스트를 랜덤으로 받아올 때 요구 개수보다 전체 생방송 수가 적거나 같으면 전체 생방송 개수만큼 불러와야 한다.', () => {
+    const liveCount = 10;
+    const live: Live = Live.getInstance();
+    getMockLiveDataList(liveCount).forEach((mockData) => live.data.set(mockData.broadcastId, mockData));
+
+    const testList1 = service.getCurrentLiveListRandomShuffle(liveCount + 10);
+
+    expect(testList1.length).toBe(liveCount);
+    live.data.clear();
+  });
 });


### PR DESCRIPTION
## Issue

- [x] #205 
- [x] #206  

<br><br>

## Detail

추천 방송 리스트와 전체 방송 목록(시청자 순) 전달 API를 구현했습니다.
이용 예시
- 전체 방송 목록 `api.funch.site/live/list?start=0&end=10`
  `start` 부터 `end` 전까지 반환합니다. 위 예시 상 0~9 번 방송

- 추천 방송 목록 `api.funch.site/live/suggest`
  현재 전체 방송에서 랜덤으로 `정해진 수` 만큼 반환하고 있고, `정해진 수`는 constants.ts의 SUGGEST_LIVE_COUNT에 정의되어 있습니다.