### PR TITLE
추천, 전체 방송 정보 반환 함수 변경

### DIFF
--- a/applicationServer/src/live/entities/live.entity.ts
+++ b/applicationServer/src/live/entities/live.entity.ts
@@ -1,15 +1,15 @@
-import { Broadcast } from '@src/types'
+import { Broadcast } from '@src/types';
 
 class Live {
-    public data: Map<string, Broadcast>;
-    private static instance: Live;
-    private constructor() {
-        this.data = new Map();
-    }
+  public data: Map<string, Broadcast>;
+  private static instance: Live;
+  private constructor() {
+    this.data = new Map();
+  }
 
-    public static getInstance() {
-        return this.instance != null ? this.instance : this.instance = new Live();
-    }
+  public static getInstance() {
+    return this.instance != null ? this.instance : (this.instance = new Live());
+  }
 }
 
-export { Live }
+export { Live };

--- a/applicationServer/src/live/live.controller.ts
+++ b/applicationServer/src/live/live.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { LiveService } from '@live/live.service';
 import { SUGGEST_LIVE_COUNT } from '@src/constants';
+import { AddMemberInfoToLive } from '@src/utils/interceptor/live.interceptor';
 
 @Controller('live')
 export class LiveController {
   constructor(private readonly liveService: LiveService) {}
 
+  @AddMemberInfoToLive()
   @Get('/list')
   getLivelistAlignViewerCount(@Query('start') start: number, @Query('end') end: number) {
     return this.liveService.getLiveList(start, end);
@@ -16,8 +18,9 @@ export class LiveController {
     return this.liveService.responsePlaylistUrl(broadcastId);
   }
 
+  @AddMemberInfoToLive()
   @Get('/list/suggest')
   getSuggestLiveList() {
-    return { suggest: this.liveService.getCurrentLiveListRandomShuffle(SUGGEST_LIVE_COUNT) };
+    return this.liveService.getRandomLiveList(SUGGEST_LIVE_COUNT);
   }
 }

--- a/applicationServer/src/live/live.module.ts
+++ b/applicationServer/src/live/live.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { LiveService } from '@live/live.service';
 import { LiveController } from '@live/live.controller';
+import { MemberModule } from '@src/member/member.module';
 
 @Module({
+  imports: [MemberModule],
   controllers: [LiveController],
   providers: [LiveService],
 })

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -28,17 +28,17 @@ export class LiveService {
     const allLives = Array.from(this.live.data.values());
     if (allLives.length <= count) return allLives;
 
-    const suggestLiveList: Broadcast[] = [];
-    while (suggestLiveList.length < count) {
+    const result: Broadcast[] = [];
+    while (result.length < count) {
       const history = {};
       const randomCount = Math.floor(allLives.length * Math.random());
 
       if (!history[randomCount]) {
-        suggestLiveList.push(allLives[randomCount]);
+        result.push(allLives[randomCount]);
         history[randomCount] = true;
       }
     }
 
-    return suggestLiveList;
+    return result;
   }
 }

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -24,21 +24,21 @@ export class LiveService {
     return playlist;
   }
 
-  getCurrentLiveListRandomShuffle(count) {
+  getRandomLiveList(count) {
     const allLives = Array.from(this.live.data.values());
     if (allLives.length <= count) return allLives;
 
-    const result: Broadcast[] = [];
-    while (result.length < count) {
+    const suggestLiveList: Broadcast[] = [];
+    while (suggestLiveList.length < count) {
       const history = {};
       const randomCount = Math.floor(allLives.length * Math.random());
 
       if (!history[randomCount]) {
-        result.push(allLives[randomCount]);
+        suggestLiveList.push(allLives[randomCount]);
         history[randomCount] = true;
       }
     }
 
-    return result;
+    return suggestLiveList;
   }
 }

--- a/applicationServer/src/member/member.entity.ts
+++ b/applicationServer/src/member/member.entity.ts
@@ -3,28 +3,28 @@ import { Entity, Column, PrimaryColumn } from 'typeorm';
 @Entity()
 class Member {
   @PrimaryColumn({ length: 255 })
-  private id: string;
+  id: string;
 
   @Column({ length: 255, nullable: false })
-  private name: string;
+  name: string;
 
   @Column({ length: 255, nullable: false })
-  private profile_image: string;
+  profile_image: string;
 
   @Column({ length: 255, nullable: false })
-  private stream_key: string;
+  stream_key: string;
 
   @Column({ length: 255, nullable: false })
-  private broadcast_id: string;
+  broadcast_id: string;
 
   @Column({ type: 'int', nullable: false })
-  private follower_count: number;
+  follower_count: number;
 
   @Column('timestamp', { name: 'created_at', nullable: false, default: () => 'CURRENT_TIMESTAMP' })
-  private createdAt: Date;
+  createdAt: Date;
 
   @Column('timestamp', { name: 'deleted_at', nullable: true })
-  private deletedAt: Date | null;
+  deletedAt: Date | null;
 }
 
 export { Member };

--- a/applicationServer/src/member/member.service.ts
+++ b/applicationServer/src/member/member.service.ts
@@ -13,6 +13,10 @@ class MemberService {
   async findMembers(): Promise<Member[]> {
     return this.memberRepository.find();
   }
+
+  async findOneMemberWithCondition(condition: { [key: string]: string }) {
+    return this.memberRepository.findOne({ where: condition });
+  }
 }
 
 export { MemberService };

--- a/applicationServer/src/utils/interceptor/live.interceptor.ts
+++ b/applicationServer/src/utils/interceptor/live.interceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler, UseInterceptors } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import { MemberService } from '@src/member/member.service';
+import { Broadcast } from '@src/types';
+
+@Injectable()
+class LiveInterceptor implements NestInterceptor {
+  constructor(private readonly memberService: MemberService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      mergeMap(async (data) => {
+        if (Array.isArray(data)) {
+          return Promise.all(
+            data.map(async (live: Broadcast) => {
+              const member = await this.memberService.findOneMemberWithCondition({ broadcast_id: live.broadcastId });
+              return { ...live, name: member.name, profileImage: member.profile_image };
+            }),
+          );
+        }
+        return data;
+      }),
+    );
+  }
+}
+
+export function AddMemberInfoToLive() {
+  return UseInterceptors(LiveInterceptor);
+}

--- a/applicationServer/test/live/live.service.spec.ts
+++ b/applicationServer/test/live/live.service.spec.ts
@@ -67,8 +67,8 @@ describe('LiveService 테스트', () => {
     const live: Live = Live.getInstance();
     getMockLiveDataList(liveCount * 3).forEach((mockData) => live.data.set(mockData.broadcastId, mockData));
 
-    const testList1 = service.getCurrentLiveListRandomShuffle(liveCount);
-    const testList2 = service.getCurrentLiveListRandomShuffle(liveCount);
+    const testList1 = service.getRandomLiveList(liveCount);
+    const testList2 = service.getRandomLiveList(liveCount);
 
     expect(testList1).not.toEqual(testList2);
     live.data.clear();
@@ -79,7 +79,7 @@ describe('LiveService 테스트', () => {
     const live: Live = Live.getInstance();
     getMockLiveDataList(liveCount).forEach((mockData) => live.data.set(mockData.broadcastId, mockData));
 
-    const testList1 = service.getCurrentLiveListRandomShuffle(liveCount + 10);
+    const testList1 = service.getRandomLiveList(liveCount + 10);
 
     expect(testList1.length).toBe(liveCount);
     live.data.clear();


### PR DESCRIPTION
## Issue

- [x] #205 
- [x] #206  

<br><br>

## Detail

- 단일 멤버 반환 함수 작성
- 기존 방송 정보만 반환하던 API를 방송 정보와 스트리머 정보를 함께 반환하도록 수정
- 위 사유로 반복 코드 인터셉터로 분리
- 함수 리네이밍
