### PR TITLE
안정적인 미디어 서버를 위한 리팩토링

### DIFF
--- a/applicationServer/src/live/live.controller.ts
+++ b/applicationServer/src/live/live.controller.ts
@@ -31,13 +31,14 @@ export class LiveController {
 
   @Post('/start')
   @HttpCode(200)
-  async startLive(@Body('streamKey') streamKey) {
+  async startLive(@Body('streamKey') streamKey: string, @Body('internalPath') internalPath: string) {
     const member = await this.liveService.verifyStreamKey(streamKey);
-    this.liveService.addLiveData(member);
+    this.liveService.addLiveData(member, internalPath);
     return { broadcastId: member.broadcast_id };
   }
 
   @Post('/end')
+  @HttpCode(200)
   async endLive(@Body('streamKey') streamKey) {
     const member = await this.liveService.verifyStreamKey(streamKey);
     this.liveService.removeLiveData(member);

--- a/applicationServer/src/types.ts
+++ b/applicationServer/src/types.ts
@@ -1,5 +1,6 @@
 type Broadcast = {
   broadcastId: string;
+  broadcastPath: string;
   title: string;
   contentCategory: string;
   moodCategory: string;

--- a/mediaServer/core/fetch.ts
+++ b/mediaServer/core/fetch.ts
@@ -1,27 +1,21 @@
+import { logger } from '@/logger';
+
+type StreamingEvent = 'start' | 'end';
 const API_SERVER_LIVE_URL = 'https://api.funch.site/live';
 
-async function startStreaming(streamKey) {
-  return fetch(`${API_SERVER_LIVE_URL}/start`, {
-    method: 'POST',
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      Connection: 'close',
-    },
-    body: JSON.stringify({ streamKey }),
-  });
+async function streamingEvent(event: StreamingEvent, data) {
+  try {
+    return fetch(`${API_SERVER_LIVE_URL}/${event}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+  } catch (e) {
+    logger.error(`fetch start stream event: ${e}`);
+    return;
+  }
 }
 
-function endStreaming(streamKey) {
-  return fetch(`${API_SERVER_LIVE_URL}/end`, {
-    method: 'POST',
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      Connection: 'close',
-    },
-    body: JSON.stringify({ streamKey }),
-  });
-}
-
-export { startStreaming, endStreaming };
+export { streamingEvent };

--- a/mediaServer/core/media/ffmpeg.ts
+++ b/mediaServer/core/media/ffmpeg.ts
@@ -15,10 +15,10 @@ const defaultOutputOptions = [
   '-hls_list_size 3',
   '-hls_segment_type fmp4',
   '-hls_flags split_by_time+independent_segments+omit_endlist',
-  '-preset veryfast',
+  '-preset ultrafast',
 ];
 
-function initializeFFMepg(ffmpegInputStream: PassThrough, storagePath: string) {
+function initializeFFMpeg(ffmpegInputStream: PassThrough, storagePath: string) {
   return ffmpeg()
     .input(ffmpegInputStream)
     .inputOptions(['-re'])
@@ -28,7 +28,7 @@ function initializeFFMepg(ffmpegInputStream: PassThrough, storagePath: string) {
     .videoCodec('libx264')
     .audioCodec('aac')
     .size('1920x1080')
-    .videoBitrate('5000k')
+    .videoBitrate('8000k')
     .audioBitrate('192k')
     .outputOptions([...defaultOutputOptions, '-hls_fmp4_init_filename chunkList_1080p_0_0.mp4'])
 
@@ -36,29 +36,19 @@ function initializeFFMepg(ffmpegInputStream: PassThrough, storagePath: string) {
     .videoCodec('libx264')
     .audioCodec('aac')
     .size('1280x720')
-    .videoBitrate('3000k')
+    .videoBitrate('5000k')
     .audioBitrate('128k')
     .outputOptions([...defaultOutputOptions, '-hls_fmp4_init_filename chunkList_720p_0_0.mp4'])
-
-    .output(`${storagePath}/chunklist_480p_.m3u8`)
-    .videoCodec('libx264')
-    .audioCodec('aac')
-    .size('854x480')
-    .videoBitrate('1500k')
-    .audioBitrate('96k')
-    .outputOptions([...defaultOutputOptions, '-hls_fmp4_init_filename chunkList_480p_0_0.mp4'])
 
     .output(`${storagePath}/dynamic_thumbnail.jpg`)
     .outputOptions(['-vf', 'fps=1/30', '-update', '1', '-s', '426x240'])
 
-    .on('end', (err, stdout, stderr) => {
-      logger.info(`Finished processing! err: ${err}, stdout: ${stdout}, stderr: ${stderr}`);
-    })
     .on('close', (code) => {
       logger.error(`FFmpeg process exited with code ${code}`);
     })
-    .on('error', (code) => {
-      logger.error(`FFmpeg process error with code ${code}`);
+    .on('error', (code, stdout, stderr) => {
+      logger.error(`FFmpeg process error with code: ${code}\nstdout: ${stdout}\nstderr: ${stderr}`);
+      initializeFFMpeg(ffmpegInputStream, storagePath);
     });
 }
 
@@ -67,16 +57,14 @@ function createMasterPlaylist(storagePath) {
 #EXTM3U
 #EXT-X-VERSION:7
 
-#EXT-X-STREAM-INF:BANDWIDTH=5711200,RESOLUTION=1920x1080,CODECS="avc1.64002a,mp4a.40.2"
+#EXT-X-STREAM-INF:BANDWIDTH=8711200,RESOLUTION=1920x1080,CODECS="avc1.64002a,mp4a.40.2"
 chunklist_1080p_.m3u8
-#EXT-X-STREAM-INF:BANDWIDTH=3440800,RESOLUTION=1280x720,CODECS="avc1.640020,mp4a.40.2"
+#EXT-X-STREAM-INF:BANDWIDTH=5440800,RESOLUTION=1280x720,CODECS="avc1.640020,mp4a.40.2"
 chunklist_720p_.m3u8
-#EXT-X-STREAM-INF:BANDWIDTH=1755600,RESOLUTION=854x480,CODECS="avc1.64001f,mp4a.40.2"
-chunklist_480p_.m3u8
 `.trim();
 
   const fileStream = fs.createWriteStream(`${storagePath}/master_playlist.m3u8`);
   fileStream.write(masterPlaylist, () => fileStream.end());
 }
 
-export { initializeFFMepg, createMasterPlaylist };
+export { initializeFFMpeg, createMasterPlaylist };

--- a/mediaServer/core/rtmp/utils.ts
+++ b/mediaServer/core/rtmp/utils.ts
@@ -1,4 +1,5 @@
 import { decodeAmf0Cmd, decodeAmf3Cmd } from 'node-amfutils';
+import { logger } from '@/logger';
 
 function decodeAMF(typeId: number, paylod: Buffer, amf0Num: number, amf3Num: number) {
   try {
@@ -8,7 +9,7 @@ function decodeAMF(typeId: number, paylod: Buffer, amf0Num: number, amf3Num: num
       return decodeAmf3Cmd(paylod);
     }
   } catch (e) {
-    console.log(typeId, JSON.stringify(paylod), e);
+    logger.debug(`[typeId${typeId}] ${JSON.stringify(paylod)}, error : ${e}`);
   }
 }
 


### PR DESCRIPTION
## Detail

- 방송 파일 경로가 기존 broadcast 이름으로 만들어진 디렉토리에서 내부 추가
디렉토리 경로가 생김에 따라 broadcast properties에 broadcastPath를
추가하였습니다.

- CPU 사용량을 줄이기 위해 FFMpeg으로 m4v 파일을 만드는 과정에서 480p 생성
코드를 제거하였습니다.

- 기존 중복된 코드였던 startStreaming과 endStreaming을 streamingEvent 함수
하나로 변경하였고, 전달받는 인자값을 streamKey와 internalPath를 함께
받을 수 있도록 객체 형태로 전달받도록 변경하였습니다.

- this.storagePath가 정해지기 전 종료 관련 이벤트가 발생했을 때
storagePath가 undefined으로 처리되는 현상을 막기 위한 소켓 이벤트 분리와
방송 종료 시 방송 디렉토리를 제거하던 로직을 삭제하고, 방송 별 디렉토리
분리로 변경함에 따라 internalPath를 방송 시작 시 함께 전달하도록
변경하였습니다.