### PR TITLE
스트리머 팔로우/언팔로우

### DIFF
--- a/applicationServer/src/app.module.ts
+++ b/applicationServer/src/app.module.ts
@@ -5,11 +5,12 @@ import { MemberModule } from '@member/member.module';
 import { LiveModule } from '@live/live.module';
 import { GithubAuthModule } from '@github/github.module';
 import { AuthModule } from '@auth/auth.module';
+import { FollowModule } from '@follow/follow.module';
 
 dotenv.config();
 
 @Module({
-  imports: [MemberModule, GithubAuthModule, AuthModule, LiveModule],
+  imports: [MemberModule, GithubAuthModule, AuthModule, LiveModule, FollowModule],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -22,3 +22,5 @@ export const BUCKET_NAME = 'media-storage';
 export const LOCALHOST = 'localhost';
 export const CORS_ORIGIN = 'https://funch.site/';
 export const CORS_ORIGIN_WWW = 'https://www.funch.site/';
+// follow.provider.ts
+export const FOLLOW_REPOSITORY = 'FOLLOW_REPOSITORY';

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -24,3 +24,6 @@ export const CORS_ORIGIN = 'https://funch.site/';
 export const CORS_ORIGIN_WWW = 'https://www.funch.site/';
 // follow.provider.ts
 export const FOLLOW_REPOSITORY = 'FOLLOW_REPOSITORY';
+// follow.controller.ts
+export const FOLLOWERS = 'followers';
+export const FOLLOWING = 'following';

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -1,6 +1,5 @@
 // member.providers.ts
 export const MEMBER_REPOSITORY = 'MEMBER_REPOSITORY';
-export const DATA_SOURCE = 'DATA_SOURCE';
 // live.controller.ts
 export const SUGGEST_LIVE_COUNT = 10;
 // live.service.ts

--- a/applicationServer/src/database/database.providers.ts
+++ b/applicationServer/src/database/database.providers.ts
@@ -1,9 +1,8 @@
 import path from 'path';
 import { DataSource } from 'typeorm';
-import { DATA_SOURCE } from '@src/constants';
 
 const databaseProvider = {
-  provide: DATA_SOURCE,
+  provide: DataSource,
   useFactory: async () => {
     const dataSource = new DataSource({
       type: 'mysql',

--- a/applicationServer/src/follow/follow.controller.ts
+++ b/applicationServer/src/follow/follow.controller.ts
@@ -39,4 +39,23 @@ export class FollowController {
       throw new HttpException('팔로우 중이지 않습니다.', HttpStatus.BAD_REQUEST);
     }
   }
+
+  @Get(':memberId')
+  async getFollows(@Param('memberId') memberId: string, @Query('search') search: string) {
+    const { condition, key } = this.getFollowConditions(search, memberId);
+
+    const results = await this.followService.findAllFollowWithCondition(condition);
+    const data = results.map((result) => result[key]);
+
+    return { [key]: data };
+  }
+
+  private getFollowConditions(search: string, memberId: string) {
+    if (search === FOLLOWERS) {
+      return { condition: { following: memberId }, key: FOLLOWERS };
+    } else if (search === FOLLOWING) {
+      return { condition: { follower: memberId }, key: FOLLOWING };
+    }
+    throw new HttpException('올바른 팔로워/팔로잉 정보 요청이 아닙니다.', HttpStatus.BAD_REQUEST);
+  }
 }

--- a/applicationServer/src/follow/follow.controller.ts
+++ b/applicationServer/src/follow/follow.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Post, UseGuards, Body, Delete, HttpException, HttpStatus, HttpCode } from '@nestjs/common';
+import { NeedLoginGuard } from '@src/auth/core/auth.guard';
+import { FollowService } from '@follow/follow.service';
+
+@Controller('follow')
+@UseGuards(NeedLoginGuard)
+export class FollowController {
+  constructor(private readonly followService: FollowService) {}
+
+  @Post()
+  @HttpCode(201)
+  async followMember(@Body('follower') follower: string, @Body('following') following: string) {
+    const isAlreadyFollowing = await this.followService.findOneFollowWithCondition({ follower, following });
+    if (isAlreadyFollowing) throw new HttpException('이미 팔로우 중입니다.', HttpStatus.BAD_REQUEST);
+
+    await this.followService.followMember(follower, following);
+  }
+
+  @Delete()
+  @HttpCode(204)
+  async unfollowMember(@Body('follower') follower: string, @Body('following') following: string) {
+    const result = await this.followService.unfollowMember(follower, following);
+    if (result.affected === 0) {
+      throw new HttpException('팔로우 중이지 않습니다.', HttpStatus.BAD_REQUEST);
+    }
+  }
+}

--- a/applicationServer/src/follow/follow.controller.ts
+++ b/applicationServer/src/follow/follow.controller.ts
@@ -1,6 +1,19 @@
-import { Controller, Post, UseGuards, Body, Delete, HttpException, HttpStatus, HttpCode } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  UseGuards,
+  Body,
+  Delete,
+  HttpException,
+  HttpStatus,
+  HttpCode,
+  Get,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { NeedLoginGuard } from '@src/auth/core/auth.guard';
 import { FollowService } from '@follow/follow.service';
+import { FOLLOWERS, FOLLOWING } from '@src/constants';
 
 @Controller('follow')
 @UseGuards(NeedLoginGuard)
@@ -10,6 +23,7 @@ export class FollowController {
   @Post()
   @HttpCode(201)
   async followMember(@Body('follower') follower: string, @Body('following') following: string) {
+    if (follower === following) throw new HttpException('본인을 팔로우할 수 없습니다.', HttpStatus.BAD_REQUEST);
     const isAlreadyFollowing = await this.followService.findOneFollowWithCondition({ follower, following });
     if (isAlreadyFollowing) throw new HttpException('이미 팔로우 중입니다.', HttpStatus.BAD_REQUEST);
 
@@ -19,6 +33,7 @@ export class FollowController {
   @Delete()
   @HttpCode(204)
   async unfollowMember(@Body('follower') follower: string, @Body('following') following: string) {
+    if (follower === following) throw new HttpException('본인을 언팔로우할 수 없습니다.', HttpStatus.BAD_REQUEST);
     const result = await this.followService.unfollowMember(follower, following);
     if (result.affected === 0) {
       throw new HttpException('팔로우 중이지 않습니다.', HttpStatus.BAD_REQUEST);

--- a/applicationServer/src/follow/follow.entity.ts
+++ b/applicationServer/src/follow/follow.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity()
+class Follow {
+  @PrimaryColumn({ length: 255 })
+  id: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  follower: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  following: string;
+
+  @Column('timestamp', { name: 'created_at', nullable: false, default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+}
+
+export { Follow };

--- a/applicationServer/src/follow/follow.module.ts
+++ b/applicationServer/src/follow/follow.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@src/database/database.module';
+import { followProvider } from '@follow/follow.providers';
+import { FollowController } from '@follow/follow.controller';
+import { FollowService } from '@follow/follow.service';
+import { AuthModule } from '@src/auth/core/auth.module';
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [FollowController],
+  providers: [followProvider, FollowService],
+  exports: [FollowService],
+})
+export class FollowModule {}

--- a/applicationServer/src/follow/follow.providers.ts
+++ b/applicationServer/src/follow/follow.providers.ts
@@ -1,0 +1,9 @@
+import { DataSource } from 'typeorm';
+import { Follow } from '@follow/follow.entity';
+import { FOLLOW_REPOSITORY } from '@src/constants';
+
+export const followProvider = {
+  provide: FOLLOW_REPOSITORY,
+  useFactory: (dataSource: DataSource) => dataSource.getRepository(Follow),
+  inject: [DataSource],
+};

--- a/applicationServer/src/follow/follow.service.ts
+++ b/applicationServer/src/follow/follow.service.ts
@@ -15,6 +15,10 @@ export class FollowService {
     return this.followRepository.findOne({ where: condition });
   }
 
+  async findAllFollowWithCondition(condition: { [key: string]: string }) {
+    return this.followRepository.find({ where: condition });
+  }
+
   async followMember(follower: string, following: string) {
     const follow = { id: crypto.randomUUID(), follower, following };
     await this.followRepository.save(follow);

--- a/applicationServer/src/follow/follow.service.ts
+++ b/applicationServer/src/follow/follow.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Follow } from '@follow/follow.entity';
+import { FOLLOW_REPOSITORY } from '@src/constants';
+import crypto from 'crypto';
+
+@Injectable()
+export class FollowService {
+  constructor(
+    @Inject(FOLLOW_REPOSITORY)
+    private readonly followRepository: Repository<Follow>,
+  ) {}
+
+  async findOneFollowWithCondition(condition: { [key: string]: string }) {
+    return this.followRepository.findOne({ where: condition });
+  }
+
+  async followMember(follower: string, following: string) {
+    const follow = { id: crypto.randomUUID(), follower, following };
+    await this.followRepository.save(follow);
+  }
+
+  async unfollowMember(follower: string, following: string) {
+    return this.followRepository.delete({ follower, following });
+  }
+}

--- a/applicationServer/src/member/member.providers.ts
+++ b/applicationServer/src/member/member.providers.ts
@@ -1,11 +1,11 @@
 import { DataSource } from 'typeorm';
 import { Member } from '@member/member.entity';
-import { MEMBER_REPOSITORY, DATA_SOURCE } from '@src/constants';
+import { MEMBER_REPOSITORY } from '@src/constants';
 
 const memberProvider = {
   provide: MEMBER_REPOSITORY,
   useFactory: (dataSource: DataSource) => dataSource.getRepository(Member),
-  inject: [DATA_SOURCE],
+  inject: [DataSource],
 };
 
 export { memberProvider };

--- a/applicationServer/tsconfig.json
+++ b/applicationServer/tsconfig.json
@@ -19,7 +19,8 @@
       "@authUtil/*": ["src/auth/util/*"],
       "@database/*": ["src/database/*"],
       "@member/*": ["src/member/*"],
-      "@live/*": ["src/live/*"]
+      "@live/*": ["src/live/*"],
+      "@follow/*": ["src/follow/*"]
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Issue

- [x] #255 
- [x] #256 


<br><br>

## Detail
* DataSource 주입 방식을 문자열 토큰 방식이 아닌 클래스 참조를 사용하도록 변경
* 멤버 팔로우/언팔로우 기능 구현
  * 로그인한 멤버가 아니라면 접근이 불가능하다. (401 Error)
  * 만약 팔로우를 이미 한 상태에서 팔로우 요청을 하면 BAD_REQUEST 오류를 발생시킨다. (400 Error)
  * 만약 팔로우를 하지 않은 상태에서 언팔로우 요청을 하면 BAD_REQUEST 오류를 발생시킨다. (400 Error)
* 본인 팔로우/언팔로우 금지 기능 추가
* 사용자의 팔로워/팔로잉 목록 가져오는 API 구현