### PR TITLE
네이버 로그인/회원가입 기능 구현

### DIFF
--- a/applicationServer/package.json
+++ b/applicationServer/package.json
@@ -69,6 +69,7 @@
       "^@member/(.*)$": "<rootDir>/src/member/$1",
       "^@auth/(.*)$": "<rootDir>/src/auth/core/$1",
       "^@github/(.*)$": "<rootDir>/src/auth/github/$1",
+      "^@naver/(.*)$": "<rootDir>/src/auth/naver/$1",
       "^@cookie/(.*)$": "<rootDir>/src/auth/cookie/$1",
       "^@authUtil/(.*)$": "<rootDir>/src/auth/util/$1"
     }

--- a/applicationServer/src/app.module.ts
+++ b/applicationServer/src/app.module.ts
@@ -6,11 +6,12 @@ import { LiveModule } from '@live/live.module';
 import { GithubAuthModule } from '@github/github.module';
 import { AuthModule } from '@auth/auth.module';
 import { FollowModule } from '@follow/follow.module';
+import { NaverAuthModule } from '@naver/naver.module';
 
 dotenv.config();
 
 @Module({
-  imports: [MemberModule, GithubAuthModule, AuthModule, LiveModule, FollowModule],
+  imports: [MemberModule, GithubAuthModule, AuthModule, LiveModule, FollowModule, NaverAuthModule],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/applicationServer/src/auth/github/github.service.ts
+++ b/applicationServer/src/auth/github/github.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import axios from 'axios';
-import { ACCESS_TOKEN_URL, APPLICATION_JSON, RESOURCE_URL } from '@src/constants';
+import { GITHUB_ACCESS_TOKEN_URL, APPLICATION_JSON, GITHUB_RESOURCE_URL } from '@src/constants';
 
 @Injectable()
 class GithubAuthService {
@@ -9,14 +9,18 @@ class GithubAuthService {
   async getAccessToken(code: string): Promise<string> {
     const request = {
       code,
-      client_id: process.env.CLIENT_ID,
-      client_secret: process.env.CLIENT_SECRETS,
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
     };
-    const response = await axios.post(ACCESS_TOKEN_URL, request, {
-      headers: {
-        accept: APPLICATION_JSON,
-      },
-    });
+    const response = await axios
+      .post(GITHUB_ACCESS_TOKEN_URL, request, {
+        headers: {
+          accept: APPLICATION_JSON,
+        },
+      })
+      .catch(() => {
+        throw new HttpException('Github AccessToken 가져오기 실패', HttpStatus.UNAUTHORIZED);
+      });
 
     if (response.data.error) {
       throw new HttpException('Github AccessToken 가져오기 실패', HttpStatus.UNAUTHORIZED);
@@ -25,11 +29,15 @@ class GithubAuthService {
   }
 
   async getUserInfo(accessToken: string) {
-    const { data } = await axios.get(RESOURCE_URL, {
-      headers: {
-        Authorization: `token ${accessToken}`,
-      },
-    });
+    const { data } = await axios
+      .get(GITHUB_RESOURCE_URL, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .catch(() => {
+        throw new HttpException('Github 유저 정보 가져오기 실패', HttpStatus.FAILED_DEPENDENCY);
+      });
 
     return data;
   }

--- a/applicationServer/src/auth/naver/naver.controller.ts
+++ b/applicationServer/src/auth/naver/naver.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Post, Body, Res, UseGuards } from '@nestjs/common';
+import { Response } from 'express';
+import { MemberService } from '@src/member/member.service';
+import { NaverAuthService } from '@naver/naver.service';
+import { AuthService } from '@auth/auth.service';
+import { CookieService } from '@cookie/cookie.service';
+import { NoNeedLoginGuard } from '@auth/auth.guard';
+import { REFRESH_TOKEN } from '@src/constants';
+
+@Controller('auth/naver')
+class NaverAuthController {
+  constructor(
+    private readonly naverAuthService: NaverAuthService,
+    private readonly memberService: MemberService,
+    private readonly authService: AuthService,
+    private readonly cookieService: CookieService,
+  ) {}
+
+  @Post('/callback')
+  @UseGuards(NoNeedLoginGuard)
+  async getAccessToken(
+    @Body('code') code: string,
+    @Body('state') state: string,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const naverAccessToken = await this.naverAuthService.getAccessToken(code, state);
+    const { id } = await this.naverAuthService.getUserInfo(naverAccessToken);
+    const member = await this.findOrRegisterMember(`Naver@${id}`);
+    const accessToken = this.authService.generateAccessToken(member.id);
+    const refreshToken = this.authService.generateRefreshToken(member.id);
+
+    this.authService.saveRefreshToken(member.id, refreshToken);
+    this.cookieService.setCookie(res, REFRESH_TOKEN, refreshToken);
+
+    return { accessToken, name: member.name, profile_image: member.profile_image, broadcast_id: member.broadcast_id };
+  }
+
+  private async findOrRegisterMember(memberId: string) {
+    const member = await this.memberService.findOneMemberWithCondition({ id: memberId });
+    if (!member) {
+      const newMember = await this.memberService.register(memberId);
+      return newMember;
+    }
+    return member;
+  }
+}
+
+export { NaverAuthController };

--- a/applicationServer/src/auth/naver/naver.module.ts
+++ b/applicationServer/src/auth/naver/naver.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { NaverAuthController } from '@naver/naver.controller';
+import { NaverAuthService } from '@naver/naver.service';
+import { DatabaseModule } from '@src/database/database.module';
+import { MemberModule } from '@src/member/member.module';
+import { AuthModule } from '@auth/auth.module';
+import { CookieModule } from '@cookie/cookie.module';
+
+@Module({
+  imports: [DatabaseModule, MemberModule, AuthModule, CookieModule],
+  controllers: [NaverAuthController],
+  providers: [NaverAuthService],
+})
+export class NaverAuthModule {}

--- a/applicationServer/src/auth/naver/naver.service.ts
+++ b/applicationServer/src/auth/naver/naver.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import axios from 'axios';
+import { NAVER_ACCESS_TOKEN_URL, NAVER_RESOURCE_URL } from '@src/constants';
+
+@Injectable()
+class NaverAuthService {
+  async getAccessToken(code: string, state: string): Promise<string> {
+    const TOKEN_REQUEST_URL = [
+      NAVER_ACCESS_TOKEN_URL,
+      '?grant_type=authorization_code',
+      `&client_id=${process.env.NAVER_CLIENT_ID}`,
+      `&client_secret=${process.env.NAVER_CLIENT_SECRET}`,
+      `&code=${code}`,
+      `&state=${state}`,
+    ]
+      .join('')
+      .trim();
+
+    const response = await axios.get(TOKEN_REQUEST_URL).catch(() => {
+      throw new HttpException('Naver AccessToken 가져오기 실패', HttpStatus.UNAUTHORIZED);
+    });
+
+    if (response.data.error) {
+      throw new HttpException('Naver AccessToken 가져오기 실패', HttpStatus.UNAUTHORIZED);
+    }
+    return response.data.access_token;
+  }
+
+  async getUserInfo(accessToken: string) {
+    const { data } = await axios
+      .get(NAVER_RESOURCE_URL, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .catch(() => {
+        throw new HttpException('Naver AccessToken 가져오기 실패', HttpStatus.UNAUTHORIZED);
+      });
+
+    return data.response;
+  }
+}
+
+export { NaverAuthService };

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -7,7 +7,10 @@ export const NOTIFY_LIVE_DATA_INTERVAL_TIME = 30000;
 // github.service.ts
 export const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 export const APPLICATION_JSON = 'application/json';
-export const RESOURCE_URL = 'https://api.github.com/user';
+export const GITHUB_RESOURCE_URL = 'https://api.github.com/user';
+// naver.service.ts
+export const NAVER_ACCESS_TOKEN_URL = 'https://nid.naver.com/oauth2.0/token';
+export const NAVER_RESOURCE_URL = 'https://openapi.naver.com/v1/nid/me';
 // member.service.ts
 export const DEFAULT_PROFILE_IMAGE = 'https://kr.object.ncloudstorage.com/funch-storage/profile/profile_default.png';
 // cookie.service.ts

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -5,7 +5,7 @@ export const SUGGEST_LIVE_COUNT = 10;
 // live.service.ts
 export const NOTIFY_LIVE_DATA_INTERVAL_TIME = 30000;
 // github.service.ts
-export const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+export const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 export const APPLICATION_JSON = 'application/json';
 export const RESOURCE_URL = 'https://api.github.com/user';
 // member.service.ts

--- a/applicationServer/src/live/mock/register-mock.util.ts
+++ b/applicationServer/src/live/mock/register-mock.util.ts
@@ -15,7 +15,7 @@ function registerMockLive(live) {
     const name = generateRandomName();
     live.data.set(mockBroadcastIdList[idx], {
       broadcastId: mockBroadcastIdList[idx],
-      boradcastPath: `${mockBroadcastIdList[idx]}`,
+      broadcastPath: `${mockBroadcastIdList[idx]}`,
       title: `${name}의 라이브 방송`,
       contentCategory: contentCategoryList[idx],
       moodCategory: moodCategoryList[idx],

--- a/applicationServer/test/auth/github/github.service.spec.ts
+++ b/applicationServer/test/auth/github/github.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GithubAuthService } from '@github/github.service';
 import axios from 'axios';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { ACCESS_TOKEN_URL, APPLICATION_JSON } from '@src/constants';
+import { GITHUB_ACCESS_TOKEN_URL, APPLICATION_JSON } from '@src/constants';
 
 jest.mock('axios');
 
@@ -30,7 +30,7 @@ describe('GithubAuthService', () => {
       const result = await githubAuthService.getAccessToken(code);
 
       expect(mockAxios.post).toHaveBeenCalledWith(
-        ACCESS_TOKEN_URL,
+        GITHUB_ACCESS_TOKEN_URL,
         {
           code,
           client_id: process.env.CLIENT_ID,
@@ -53,7 +53,7 @@ describe('GithubAuthService', () => {
       );
 
       expect(mockAxios.post).toHaveBeenCalledWith(
-        ACCESS_TOKEN_URL,
+        GITHUB_ACCESS_TOKEN_URL,
         {
           code,
           client_id: process.env.CLIENT_ID,

--- a/applicationServer/tsconfig.json
+++ b/applicationServer/tsconfig.json
@@ -16,6 +16,7 @@
       "@auth/*": ["src/auth/core/*"],
       "@cookie/*": ["src/auth/cookie/*"],
       "@github/*": ["src/auth/github/*"],
+      "@naver/*": ["src/auth/naver/*"],
       "@authUtil/*": ["src/auth/util/*"],
       "@database/*": ["src/database/*"],
       "@member/*": ["src/member/*"],


### PR DESCRIPTION
## Issue

- [x] #261 


<br><br>

## Detail

- 네이버 로그인 API를 이용한 회원가입 및 로그인 로직을 구현하였습니다.
https://www.notion.so/zzawang/Naver-56dc615ab5fe4048b994196956b77d5c

- github 로그인 service 로직에 axios시 2xx 응답이 돌아오지 않아 프로세스가
종료되는 것을 방지하기 위해 catch로 에러를 처리할 수 있는 로직을
추가했습니다. 추가로 getUserInfo의 authorization header의 token type을
Token -> Bearer로 변경하였습니다.

- Github 로그인 시 사용하던 상수의 이름을 naver 로그인 추가에 따라
보편적인 이름에서 로그인 사이트를 특정할 수 있도록 변경하였습니다.
ex) RESOURCE_URL -> GITHUB_RESOURCE_URL