### PR TITLE
feat: 라이브 프로바이더 개선, SSE 통신

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -2,6 +2,9 @@ const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production',
+  },
   rewrites: async () => {
     return [
       {

--- a/client/src/app/(domain)/categories/features/ContentsCategoryImage.tsx
+++ b/client/src/app/(domain)/categories/features/ContentsCategoryImage.tsx
@@ -1,5 +1,5 @@
 import { CONTENTS_CATEGORY } from '@libs/constants';
-import { ContentsCategoryKey } from '@libs/internalTypes';
+import type { ContentsCategoryKey } from '@libs/internalTypes';
 import Image from 'next/image';
 import talkImage from '@assets/categories/communication.svg';
 import gameImage from '@assets/categories/game.svg';

--- a/client/src/app/(domain)/categories/features/MoodsCategoryPalette.tsx
+++ b/client/src/app/(domain)/categories/features/MoodsCategoryPalette.tsx
@@ -1,5 +1,5 @@
 import { MOODS_CATEGORY } from '@libs/constants';
-import { MoodsCategoryKey } from '@libs/internalTypes';
+import type { MoodsCategoryKey } from '@libs/internalTypes';
 import clsx from 'clsx';
 
 type Props = {

--- a/client/src/app/(domain)/features/live/Chat.tsx
+++ b/client/src/app/(domain)/features/live/Chat.tsx
@@ -11,6 +11,7 @@ import { io, type Socket } from 'socket.io-client';
 type ChatType = {
   name: string;
   content: string;
+  color?: string;
 };
 
 type SendChat = (args: { socketRef: MutableRefObject<Socket | null>; name: string; content: string }) => void;
@@ -62,7 +63,7 @@ const ChatWrapper = ({ children }: Props) => {
       setIsSocketConnected(true);
     });
 
-    socket.on(SOCKET_EVENT.CHAT, (receivedData: { name: string; content: string }) => {
+    socket.on(SOCKET_EVENT.CHAT, (receivedData: ChatType) => {
       // 상태 업데이트
       console.log('😇 RECEIVING : ', receivedData);
       setChatList((prev) => [...prev, receivedData]);
@@ -131,7 +132,13 @@ const ChatList = ({ chatList }: ChatListProps) => {
           <div className="funch-scrollable absolute bottom-0 max-h-full w-full">
             {chatList.map((chat, index) => (
               <p key={index} className="funch-medium14">
-                <span>{chat.name}</span>
+                <span
+                  style={{
+                    color: chat?.color || 'var(--content-neutral-primary)',
+                  }}
+                >
+                  {chat.name}
+                </span>
                 <span>{chat.content}</span>
               </p>
             ))}

--- a/client/src/app/(domain)/features/live/Live.tsx
+++ b/client/src/app/(domain)/features/live/Live.tsx
@@ -12,7 +12,7 @@ import {
   useState,
 } from 'react';
 import clsx from 'clsx';
-import LiveInfo from './LiveInfo';
+// import LiveInfo from './LiveInfo';
 import useFullscreen from '@hooks/useFullscreen';
 import usePip from '@hooks/usePip';
 import useMouseMovementOnElement from '@hooks/useMouseMovementOnElement';
@@ -174,7 +174,7 @@ const Live = Object.assign(LiveController, {
   Wrapper: LiveWrapper,
   VideoWrapper,
   Video,
-  Info: LiveInfo,
+  // Info: LiveInfo,
 });
 
 export default Live;

--- a/client/src/app/(domain)/features/live/Live.tsx
+++ b/client/src/app/(domain)/features/live/Live.tsx
@@ -12,7 +12,6 @@ import {
   useState,
 } from 'react';
 import clsx from 'clsx';
-// import LiveInfo from './LiveInfo';
 import useFullscreen from '@hooks/useFullscreen';
 import usePip from '@hooks/usePip';
 import useMouseMovementOnElement from '@hooks/useMouseMovementOnElement';

--- a/client/src/app/(domain)/features/live/LiveInfo.tsx
+++ b/client/src/app/(domain)/features/live/LiveInfo.tsx
@@ -14,7 +14,6 @@ type Props = {
 };
 
 const LiveInfoWrapper = ({ children }: Props) => {
-  // const [isHovered, setIsHovered] = useState(false);
   const { liveInfo, refreshLiveInfo, broadcastId } = useLiveContext();
   const eventSourceRef = useRef<EventSource | null>(null);
 
@@ -49,67 +48,7 @@ const LiveInfoWrapper = ({ children }: Props) => {
     };
   }, [broadcastId]);
 
-  return (
-    <div className="px-7 pb-6 pt-4">
-      {children({ liveInfo })}
-      {/* <h3 className="funch-bold20 text-content-neutral-strong">{liveInfo.title}</h3>
-      <div className="mt-4 flex">
-        <div
-          className="relative h-16 w-16"
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-        >
-          <div className="relative h-full w-full p-1.5">
-            <div className="relative h-full w-full overflow-hidden rounded-full">
-              <Image
-                fill={true}
-                sizes="100%"
-                src={liveInfo.profileImageUrl}
-                alt={`스트리머 ${liveInfo.userName}의 프로필 이미지`}
-              />
-            </div>
-          </div>
-          <div
-            className={clsx(
-              'border-border-brand-base absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 rounded-full border-solid',
-              isHovered ? 'border-4' : 'border-2',
-            )}
-          />
-        </div>
-        <div className="ml-2.5 w-60">
-          <h4
-            title={liveInfo.userName}
-            className="text-content-neutral-strong funch-bold16 w-full overflow-hidden text-ellipsis whitespace-nowrap"
-          >
-            {liveInfo.userName}
-          </h4>
-          {liveInfo.tags.length > 0 && (
-            <ul className="mt-1.5 flex gap-1">
-              {liveInfo.tags.map((tag, idx) => (
-                <li key={idx}>
-                  <Badge componentType="OUTLINE">{tag}</Badge>
-                </li>
-              ))}
-            </ul>
-          )}
-          <p className="mt-1">
-            <span className="funch-medium12 text-content-neutral-base">{comma(liveInfo.viewerCount)}명 시청 중</span>
-          </p>
-        </div>
-        <div className="ml-4 pt-5">
-          <button
-            className={clsx(
-              'inline-flex h-8 items-center gap-0.5 rounded-full pl-3.5 pr-4',
-              'bg-surface-brand-strong text-content-neutral-inverse hover:bg-surface-brand-base',
-            )}
-          >
-            <HeartSvg />
-            <span className="funch-meta14">팔로우</span>
-          </button>
-        </div>
-      </div> */}
-    </div>
-  );
+  return <div className="px-7 pb-6 pt-4">{children({ liveInfo })}</div>;
 };
 
 const LiveInfoTitle = memo(({ title }: { title: string }) => {

--- a/client/src/app/(domain)/features/live/LiveInfo.tsx
+++ b/client/src/app/(domain)/features/live/LiveInfo.tsx
@@ -4,12 +4,17 @@ import HeartSvg from '@components/svgs/HeartSvg';
 import useLiveContext from '@hooks/useLiveContext';
 import clsx from 'clsx';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { memo, type PropsWithChildren, type ReactNode, useEffect, useRef, useState } from 'react';
 import Badge from '@app/(domain)/features/Badge';
 import { comma } from '@libs/formats';
+import type { Broadcast } from '@libs/internalTypes';
 
-const LiveInfo = () => {
-  const [isHovered, setIsHovered] = useState(false);
+type Props = {
+  children: (args: { liveInfo: Broadcast }) => ReactNode;
+};
+
+const LiveInfoWrapper = ({ children }: Props) => {
+  // const [isHovered, setIsHovered] = useState(false);
   const { liveInfo, refreshLiveInfo, broadcastId } = useLiveContext();
   const eventSourceRef = useRef<EventSource | null>(null);
 
@@ -46,7 +51,8 @@ const LiveInfo = () => {
 
   return (
     <div className="px-7 pb-6 pt-4">
-      <h3 className="funch-bold20 text-content-neutral-strong">{liveInfo.title}</h3>
+      {children({ liveInfo })}
+      {/* <h3 className="funch-bold20 text-content-neutral-strong">{liveInfo.title}</h3>
       <div className="mt-4 flex">
         <div
           className="relative h-16 w-16"
@@ -101,9 +107,98 @@ const LiveInfo = () => {
             <span className="funch-meta14">팔로우</span>
           </button>
         </div>
-      </div>
+      </div> */}
     </div>
   );
 };
+
+const LiveInfoTitle = memo(({ title }: { title: string }) => {
+  return <h3 className="funch-bold20 text-content-neutral-strong">{title}</h3>;
+});
+
+const LiveInfoDetailWrapper = ({ children }: PropsWithChildren) => {
+  return <div className="mt-4 grid w-full grid-cols-[4rem,1fr,6rem] gap-2.5">{children}</div>;
+};
+
+const LiveInfoProfileImage = memo(({ profileImageUrl, userName }: { profileImageUrl: string; userName: string }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  return (
+    <div className="relative h-16" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+      <div className="relative h-full w-full p-1.5">
+        <div className="relative h-full w-full overflow-hidden rounded-full">
+          <Image fill={true} sizes="100%" src={profileImageUrl} alt={`스트리머 ${userName}의 프로필 이미지`} />
+        </div>
+      </div>
+      <div
+        className={clsx(
+          'border-border-brand-base absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 rounded-full border-solid',
+          isHovered ? 'border-4' : 'border-2',
+        )}
+      />
+    </div>
+  );
+});
+
+const LiveInfoDescription = ({ children }: PropsWithChildren) => {
+  return <div className="w-60">{children}</div>;
+};
+
+const LiveInfoUserName = memo(({ userName }: { userName: string }) => {
+  return (
+    <h4
+      title={userName}
+      className="text-content-neutral-strong funch-bold16 w-full overflow-hidden text-ellipsis whitespace-nowrap"
+    >
+      {userName}
+    </h4>
+  );
+});
+
+const LiveInfoTags = memo(
+  ({ contentCategory, moodCategory, tags }: { contentCategory: string; moodCategory: string; tags: string[] }) => {
+    const allTags = [contentCategory, moodCategory, ...tags];
+
+    return (
+      <ul className="mt-1.5 flex flex-wrap gap-1">
+        {allTags.map((tag, idx) => (
+          <li key={idx}>
+            <Badge componentType="OUTLINE">{tag}</Badge>
+          </li>
+        ))}
+      </ul>
+    );
+  },
+);
+
+const LiveInfoViewerCount = memo(({ viewerCount }: { viewerCount: number }) => {
+  return <span className="funch-medium12 text-content-neutral-base">{comma(viewerCount)}명 시청 중</span>;
+});
+
+const LiveInfoFollowButton = () => {
+  return (
+    <div className="pt-5">
+      <button
+        className={clsx(
+          'inline-flex h-8 items-center gap-0.5 rounded-full pl-3.5 pr-4',
+          'bg-surface-brand-strong text-content-neutral-inverse hover:bg-surface-brand-base',
+        )}
+      >
+        <HeartSvg />
+        <span className="funch-meta14">팔로우</span>
+      </button>
+    </div>
+  );
+};
+
+const LiveInfo = Object.assign(LiveInfoWrapper, {
+  Title: LiveInfoTitle,
+  Wrapper: LiveInfoDetailWrapper,
+  ProfileImage: LiveInfoProfileImage,
+  Description: LiveInfoDescription,
+  UserName: LiveInfoUserName,
+  Tags: LiveInfoTags,
+  ViewerCount: LiveInfoViewerCount,
+  FollowButton: LiveInfoFollowButton,
+});
 
 export default LiveInfo;

--- a/client/src/app/(domain)/features/live/LiveSection.tsx
+++ b/client/src/app/(domain)/features/live/LiveSection.tsx
@@ -104,7 +104,7 @@ const LiveSection = () => {
           </Live.Wrapper>
         )}
       </Live>
-      {isLivePage && (
+      {/* {isLivePage && (
         <Chat>
           {({ chatList, isSocketConnected, socketRef, chatname, sendChat }) => (
             <>
@@ -117,7 +117,7 @@ const LiveSection = () => {
             </>
           )}
         </Chat>
-      )}
+      )} */}
     </Wrapper>
   );
 };

--- a/client/src/app/(domain)/features/live/LiveSection.tsx
+++ b/client/src/app/(domain)/features/live/LiveSection.tsx
@@ -8,6 +8,7 @@ import { type PropsWithChildren } from 'react';
 import VideoController from './VideoController';
 import MiniPlayerController from './MiniPlayerController';
 import Chat from './Chat';
+import LiveInfo from './LiveInfo';
 
 const LiveSection = () => {
   const { isLivePage, liveUrl } = useLiveContext();
@@ -100,11 +101,32 @@ const LiveSection = () => {
                 </VideoController.Wrapper>
               </VideoController>
             </Live.VideoWrapper>
-            {isLivePage && <Live.Info />}
+            {isLivePage && (
+              <LiveInfo>
+                {({ liveInfo }) => (
+                  <>
+                    <LiveInfo.Title title={liveInfo.title} />
+                    <LiveInfo.Wrapper>
+                      <LiveInfo.ProfileImage profileImageUrl={liveInfo.profileImageUrl} userName={liveInfo.userName} />
+                      <LiveInfo.Description>
+                        <LiveInfo.UserName userName={liveInfo.userName} />
+                        <LiveInfo.Tags
+                          tags={liveInfo.tags}
+                          contentCategory={liveInfo.contentCategory}
+                          moodCategory={liveInfo.moodCategory}
+                        />
+                        <LiveInfo.ViewerCount viewerCount={liveInfo.viewerCount} />
+                      </LiveInfo.Description>
+                      <LiveInfo.FollowButton />
+                    </LiveInfo.Wrapper>
+                  </>
+                )}
+              </LiveInfo>
+            )}
           </Live.Wrapper>
         )}
       </Live>
-      {/* {isLivePage && (
+      {isLivePage && (
         <Chat>
           {({ chatList, isSocketConnected, socketRef, chatname, sendChat }) => (
             <>
@@ -117,7 +139,7 @@ const LiveSection = () => {
             </>
           )}
         </Chat>
-      )} */}
+      )}
     </Wrapper>
   );
 };

--- a/client/src/app/providers/LiveProvider.tsx
+++ b/client/src/app/providers/LiveProvider.tsx
@@ -11,6 +11,7 @@ type LiveContextType = {
   liveUrl: Playlist['playlistUrl'] | null;
   broadcastId: string;
   clear: () => void;
+  refreshLiveInfo: (updatedBroadcast: Broadcast) => void;
 };
 
 const defaultLiveInfo: Broadcast = {
@@ -44,6 +45,10 @@ const LiveProvider = ({ children }: PropsWithChildren) => {
   const clear = () => {
     setLiveInfo(defaultLiveInfo);
     setLiveUrl(null);
+  };
+
+  const refreshLiveInfo = (updatedBroadcast: Broadcast) => {
+    setLiveInfo(updatedBroadcast);
   };
 
   /*
@@ -107,6 +112,7 @@ const LiveProvider = ({ children }: PropsWithChildren) => {
         liveUrl,
         broadcastId: id,
         clear,
+        refreshLiveInfo,
       }}
     >
       {isError ? <p>에러 아님</p> : isLivePage && isLoading ? <p>방송을 불러오는 중</p> : children}

--- a/client/src/app/providers/LiveProvider.tsx
+++ b/client/src/app/providers/LiveProvider.tsx
@@ -34,6 +34,7 @@ const LiveProvider = ({ children }: PropsWithChildren) => {
   const [liveInfo, setLiveInfo] = useState<Broadcast>(defaultLiveInfo);
 
   const { id } = useParams() as { id: string };
+  const [savedId, setSavedId] = useState<string | null>(null);
 
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -75,12 +76,15 @@ const LiveProvider = ({ children }: PropsWithChildren) => {
     const fetchLive = async (id: string) => {
       try {
         if (!id) return;
+        if (id === savedId) return;
+
         setIsLoading(true);
 
         const fetchedPlaylist = await getPlaylist(id);
 
         setLiveUrl(fetchedPlaylist.playlistUrl);
         setLiveInfo(fetchedPlaylist.broadcastData);
+        setSavedId(id);
         setIsLoading(false);
       } catch (err) {
         setIsError(true);
@@ -93,7 +97,7 @@ const LiveProvider = ({ children }: PropsWithChildren) => {
       // id로 스트리밍 중인 방송이 있는지 확인
       fetchLive(id);
     }
-  }, [id, isLivePage]);
+  }, [id, isLivePage, savedId]);
 
   return (
     <LiveContext.Provider


### PR DESCRIPTION
## Issue

- [x] #287 
- [x] #282 


<br><br>

## Detail

- savedId 상태를 LiveProvider에 추가하고 이팩트에 비교 조건문을 추가
- LiveInfo 컴포넌트에 SSE 통신 이팩트 추가
- LiveInfo 각 요소 메모이제이션
- 채팅 컴포넌트 소켓 통신 데이터 타입에 컬러 추가
- production에서 콘솔 로그 미노출