### PR TITLE
Follow API 테스트 코드 추가 및 버그 수정

### DIFF
--- a/applicationServer/package.json
+++ b/applicationServer/package.json
@@ -71,7 +71,8 @@
       "^@github/(.*)$": "<rootDir>/src/auth/github/$1",
       "^@naver/(.*)$": "<rootDir>/src/auth/naver/$1",
       "^@cookie/(.*)$": "<rootDir>/src/auth/cookie/$1",
-      "^@authUtil/(.*)$": "<rootDir>/src/auth/util/$1"
+      "^@authUtil/(.*)$": "<rootDir>/src/auth/util/$1",
+      "^@follow/(.*)$": "<rootDir>/src/follow/$1"
     }
   }
 }

--- a/applicationServer/src/constants.ts
+++ b/applicationServer/src/constants.ts
@@ -28,5 +28,6 @@ export const CORS_ORIGIN_WWW = 'https://www.funch.site/';
 // follow.provider.ts
 export const FOLLOW_REPOSITORY = 'FOLLOW_REPOSITORY';
 // follow.controller.ts
+export const FOLLOWER = 'follower';
 export const FOLLOWERS = 'followers';
 export const FOLLOWING = 'following';

--- a/applicationServer/src/follow/follow.controller.ts
+++ b/applicationServer/src/follow/follow.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { NeedLoginGuard } from '@src/auth/core/auth.guard';
 import { FollowService } from '@follow/follow.service';
-import { FOLLOWERS, FOLLOWING } from '@src/constants';
+import { FOLLOWER, FOLLOWERS, FOLLOWING } from '@src/constants';
 
 @Controller('follow')
 @UseGuards(NeedLoginGuard)
@@ -47,15 +47,15 @@ export class FollowController {
     const results = await this.followService.findAllFollowWithCondition(condition);
     const data = results.map((result) => result[key]);
 
-    return { [key]: data };
+    return { [search]: data };
   }
 
   private getFollowConditions(search: string, memberId: string) {
     if (search === FOLLOWERS) {
-      return { condition: { following: memberId }, key: FOLLOWERS };
+      return { condition: { following: memberId }, key: FOLLOWER };
     } else if (search === FOLLOWING) {
       return { condition: { follower: memberId }, key: FOLLOWING };
     }
-    throw new HttpException('올바른 팔로워/팔로잉 정보 요청이 아닙니다.', HttpStatus.BAD_REQUEST);
+    throw new HttpException('올바른 팔로워/팔로잉 리스트 요청이 아닙니다.', HttpStatus.BAD_REQUEST);
   }
 }

--- a/applicationServer/test/app.e2e-spec.ts
+++ b/applicationServer/test/app.e2e-spec.ts
@@ -16,9 +16,6 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
   });
 });

--- a/applicationServer/test/follow/follow.controller.spec.ts
+++ b/applicationServer/test/follow/follow.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FollowController } from '@follow/follow.controller';
+import { FollowService } from '@follow/follow.service';
+import { NeedLoginGuard } from '@src/auth/core/auth.guard';
+import { HttpException } from '@nestjs/common';
+
+describe('FollowController 테스트', () => {
+  let followController: FollowController;
+  let followService: FollowService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FollowController],
+      providers: [
+        {
+          provide: FollowService,
+          useValue: {
+            findOneFollowWithCondition: jest.fn(),
+            findAllFollowWithCondition: jest.fn(),
+            followMember: jest.fn(),
+            unfollowMember: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(NeedLoginGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    followController = module.get(FollowController);
+    followService = module.get(FollowService);
+  });
+
+  it('이미 팔로우 중인 상태라면 팔로우할 수 없다.', async () => {
+    jest.spyOn(followService, 'findOneFollowWithCondition').mockResolvedValueOnce({
+      id: 'id',
+      follower: 'user1',
+      following: 'user2',
+      createdAt: new Date(),
+    });
+
+    await expect(followController.followMember('user1', 'user2')).rejects.toThrow(
+      new HttpException('이미 팔로우 중입니다.', 400),
+    );
+  });
+
+  it('본인을 팔로우할 수 없다.', async () => {
+    await expect(followController.followMember('user1', 'user1')).rejects.toThrow(
+      new HttpException('본인을 팔로우할 수 없습니다.', 400),
+    );
+  });
+
+  it('팔로우 요청을 정상적으로 처리 할 수 있다.', async () => {
+    jest.spyOn(followService, 'findOneFollowWithCondition').mockResolvedValueOnce(undefined);
+    jest.spyOn(followService, 'followMember').mockResolvedValueOnce(undefined);
+
+    await expect(followController.followMember('user1', 'user2')).resolves;
+  });
+
+  it('언팔로우 요청을 정상적으로 처리 할 수 있다.', async () => {
+    jest.spyOn(followService, 'unfollowMember').mockResolvedValueOnce({ affected: 1, raw: {} });
+
+    await expect(followController.unfollowMember('user1', 'user2')).resolves;
+  });
+
+  it('특정 유저의 팔로워 리스트를 정상적으로 반환한다.', async () => {
+    jest
+      .spyOn(followService, 'findAllFollowWithCondition')
+      .mockResolvedValueOnce([{ id: 'id', follower: 'user1', following: 'user2', createdAt: new Date() }]);
+
+    const result = await followController.getFollows('user2', 'followers');
+
+    expect(result).toEqual({ followers: ['user1'] });
+  });
+
+  it('특정 유저의 팔로잉 리스트를 정상적으로 반환한다.', async () => {
+    jest
+      .spyOn(followService, 'findAllFollowWithCondition')
+      .mockResolvedValueOnce([{ id: 'id', follower: 'user1', following: 'user2', createdAt: new Date() }]);
+
+    const result = await followController.getFollows('user1', 'following');
+
+    expect(result).toEqual({ following: ['user2'] });
+  });
+
+  it('특정 유저의 팔로워/팔로잉 리스트 요청이 아닌 요청에 대해서는 예외를 발생시킨다.', async () => {
+    await expect(followController.getFollows('user1', 'invalid')).rejects.toThrow(
+      new HttpException('올바른 팔로워/팔로잉 리스트 요청이 아닙니다.', 400),
+    );
+  });
+});


### PR DESCRIPTION
## Issue

- [x] #255 
- [x] #256 


<br><br>

## Detail
* 팔로워 매핑 key 수정
  *  상수화 과정 중 팔로워 리스트를 추출하는 키에 S를 추가하여 FOLLOWER가 아닌 FOLLOWERS로 등록했었다. 테스트 과정 중 해당 버그를 발견하게 되어 FOLLOWERS -> FOLLOWER로 수정 후 정상적으로 추출하도록 변경하였다.
* follow 기능 테스트 코드 추가