### PR TITLE
팔로우 방송 목록 반환 API 구현

### DIFF
--- a/applicationServer/src/live/live.controller.ts
+++ b/applicationServer/src/live/live.controller.ts
@@ -25,6 +25,15 @@ export class LiveController {
     return this.liveService.filterWithCategory(liveList, query);
   }
 
+  @UseGuards(NeedLoginGuard)
+  @Get('/follow')
+  getFollowLiveList(@Req() req: Request) {
+    const accessToken = req.headers['authorization']?.split(' ')[1];
+    const decodedPayload = this.authService.verifyToken(accessToken);
+
+    return this.liveService.filterWithFollow(decodedPayload.memberId);
+  }
+
   @Get(':broadcastId')
   getPlaylistUrl(@Param('broadcastId') broadcastId: string) {
     return this.liveService.responseLiveData(broadcastId);

--- a/applicationServer/src/live/live.service.ts
+++ b/applicationServer/src/live/live.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { Live } from '@live/entities/live.entity';
-import { Broadcast } from '@src/types';
+import { Broadcast, User } from '@src/types';
 import { MemberService } from '@src/member/member.service';
 import { Member } from '@src/member/member.entity';
 import { interval, map } from 'rxjs';
@@ -118,5 +118,30 @@ export class LiveService {
         live.contentCategory == (condition.content ?? 'unknown') || live.moodCategory == (condition.mood ?? 'unknown')
       );
     });
+  }
+
+  async filterWithFollow(memberId) {
+    const followList = await this.memberService.findMembersWithFollowTable(memberId);
+    const onAir = [];
+    const offAir = [];
+    followList.forEach((member) => {
+      if (this.live.data.has(member.broadcast_id)) {
+        onAir.push(this.live.data.get(member.broadcast_id));
+      } else {
+        const { name, profile_image, broadcast_id, follower_count } = member;
+
+        offAir.push({
+          name,
+          profile_image,
+          broadcast_id,
+          follower_count,
+        } as User);
+      }
+    });
+
+    return {
+      onAir,
+      offAir,
+    };
   }
 }

--- a/applicationServer/src/member/member.service.ts
+++ b/applicationServer/src/member/member.service.ts
@@ -16,6 +16,14 @@ class MemberService {
     return this.memberRepository.find();
   }
 
+  async findMembersWithFollowTable(id) {
+    return this.memberRepository
+      .createQueryBuilder('member')
+      .innerJoin('follow', 'f', 'f.following = member.id')
+      .where('f.follower = :id', { id })
+      .getMany();
+  }
+
   async findOneMemberWithCondition(condition: { [key: string]: string }) {
     return this.memberRepository.findOne({ where: condition });
   }

--- a/applicationServer/src/types.ts
+++ b/applicationServer/src/types.ts
@@ -18,10 +18,9 @@ type Token = {
 
 type User = {
   name: string;
-  profileImageUrl: string;
-  broadcastId: string;
-  followerCount: number;
-  isLive: boolean;
+  profile_image: string;
+  broadcast_id: string;
+  follower_count: number;
 };
 
 export { Broadcast, Token, User };


### PR DESCRIPTION
## Issue

- [x] #207 


<br><br>

## Detail

- 팔로잉된 스트리머를 기준으로 방송 중이라면 방송 정보를, 아니라면
스트리머 정보를 반환하는 API를 구현하였습니다.

- 멤버 데이터를 팔로잉 기준으로 가져올 수 있도록 테이블을 조인해 반환하는
쿼리 함수를 작성하였습니다.

- User 타입을 클라이언트에서 일관성있게 사용할 수 있도록 기존 MyData를 반환하는 형태로 속성 이름을 변경하였고, 팔로잉 방송 목록을 반환할 때 온라인은 방송 정보를, 오프라인은 스트리머 정보를 반환하기 때문에 isLive 속성은 제거하였습니다.