### PR TITLE
refresh 호출 컴포넌트 및 액션

### DIFF
--- a/client/src/app/(auth)/github/callback/features/AuthGithub.tsx
+++ b/client/src/app/(auth)/github/callback/features/AuthGithub.tsx
@@ -2,7 +2,7 @@
 
 import useInternalRouter from '@hooks/useInternalRouter';
 import { authenticateByGithub } from '@libs/actions';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useUser from '@hooks/useUser';
 import AuthLoading from '@app/(auth)/features/AuthLoading';
 
@@ -10,18 +10,17 @@ type Props = {
   authCode: string;
 };
 
-let isValidCall = true;
-
 const AuthGithub = ({ authCode }: Props) => {
+  const isValidCallRef = useRef(true);
   const { saveUserSession } = useUser();
   const { replace } = useInternalRouter();
   useEffect(() => {
     let isValidEffect = true;
     const fetchUser = async (code: string) => {
       try {
-        if (!isValidCall) return;
+        if (!isValidCallRef.current) return;
         const fetchResult = await authenticateByGithub(code);
-        isValidCall = false;
+        isValidCallRef.current = false;
         if (!isValidEffect) return;
         saveUserSession(fetchResult);
       } catch (err) {

--- a/client/src/app/(auth)/google/callback/features/AuthGoogle.tsx
+++ b/client/src/app/(auth)/google/callback/features/AuthGoogle.tsx
@@ -2,7 +2,7 @@
 
 import useInternalRouter from '@hooks/useInternalRouter';
 import { authenticateByGoogle } from '@libs/actions';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useUser from '@hooks/useUser';
 import AuthLoading from '@app/(auth)/features/AuthLoading';
 
@@ -10,18 +10,17 @@ type Props = {
   authCode: string;
 };
 
-let isValidCall = true;
-
 const AuthGoogle = ({ authCode }: Props) => {
+  const isValidCallRef = useRef(true);
   const { saveUserSession } = useUser();
   const { replace } = useInternalRouter();
   useEffect(() => {
     let isValidEffect = true;
     const fetchUser = async (code: string) => {
       try {
-        if (!isValidCall) return;
+        if (!isValidCallRef.current) return;
         const fetchResult = await authenticateByGoogle(code);
-        isValidCall = false;
+        isValidCallRef.current = false;
         if (!isValidEffect) return;
         saveUserSession(fetchResult);
       } catch (err) {

--- a/client/src/app/(auth)/naver/callback/features/AuthNaver.tsx
+++ b/client/src/app/(auth)/naver/callback/features/AuthNaver.tsx
@@ -2,7 +2,7 @@
 
 import useInternalRouter from '@hooks/useInternalRouter';
 import { authenticateByNaver } from '@libs/actions';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useUser from '@hooks/useUser';
 import AuthLoading from '@app/(auth)/features/AuthLoading';
 
@@ -11,21 +11,20 @@ type Props = {
   authState: string;
 };
 
-let isValidCall = true;
-
 const AuthNaver = ({ authCode, authState }: Props) => {
+  const isValidCallRef = useRef(true);
   const { saveUserSession } = useUser();
   const { replace } = useInternalRouter();
   useEffect(() => {
     let isValidEffect = true;
     const fetchUser = async (code: string, state: string) => {
       try {
-        if (!isValidCall) return;
+        if (!isValidCallRef.current) return;
         const fetchResult = await authenticateByNaver({
           code,
           state,
         });
-        isValidCall = false;
+        isValidCallRef.current = false;
         if (!isValidEffect) return;
         saveUserSession(fetchResult);
       } catch (err) {

--- a/client/src/app/auth/refresh/features/AuthRefresh.tsx
+++ b/client/src/app/auth/refresh/features/AuthRefresh.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import useUser from '@hooks/useUser';
+import { refreshAccessToken } from '@libs/actions';
+import { COOKIE_USER_KEY } from '@libs/constants';
+import Cookies from 'js-cookie';
+import { useEffect } from 'react';
+
+const AuthRefresh = () => {
+  const { logout } = useUser();
+  useEffect(() => {
+    (async () => {
+      try {
+        const { accessToken } = await refreshAccessToken();
+        Cookies.set(COOKIE_USER_KEY, accessToken);
+        location.href = '/';
+      } catch (err) {
+        alert('다시 로그인해주세요.');
+        logout();
+      }
+    })();
+  }, []);
+  return null;
+};
+
+export default AuthRefresh;

--- a/client/src/app/auth/refresh/features/AuthRefresh.tsx
+++ b/client/src/app/auth/refresh/features/AuthRefresh.tsx
@@ -4,21 +4,31 @@ import useUser from '@hooks/useUser';
 import { refreshAccessToken } from '@libs/actions';
 import { COOKIE_USER_KEY } from '@libs/constants';
 import Cookies from 'js-cookie';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const AuthRefresh = () => {
+  const isValidCallRef = useRef(true);
   const { logout } = useUser();
   useEffect(() => {
+    let isValidEffect = true;
     (async () => {
       try {
+        if (!isValidCallRef.current) return;
         const { accessToken } = await refreshAccessToken();
+        if (!isValidEffect) return;
+        isValidCallRef.current = false;
         Cookies.set(COOKIE_USER_KEY, accessToken);
         location.href = '/';
       } catch (err) {
+        if (!isValidEffect) return;
         alert('다시 로그인해주세요.');
         logout();
       }
     })();
+
+    return () => {
+      isValidEffect = false;
+    };
   }, []);
   return null;
 };

--- a/client/src/app/auth/refresh/page.tsx
+++ b/client/src/app/auth/refresh/page.tsx
@@ -1,0 +1,16 @@
+import AuthRefresh from './features/AuthRefresh';
+
+const AuthRefreshPage = () => {
+  return (
+    <>
+      <AuthRefresh />
+      <div className="fixed left-0 top-0 flex h-screen w-screen items-center justify-center">
+        <div className="flex flex-col items-center">
+          <p className="funch-bold20 text-content-neutral-primary">재인증 중...</p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AuthRefreshPage;

--- a/client/src/app/providers/UserProvider.tsx
+++ b/client/src/app/providers/UserProvider.tsx
@@ -3,8 +3,6 @@
 import { createContext, useCallback, useEffect, useState, type PropsWithChildren } from 'react';
 import type { InternalUserSession } from '@libs/internalTypes';
 import { COOKIE_USER_KEY, LOCAL_STORAGE_USER_KEY } from '@libs/constants';
-import useInternalRouter from '@hooks/useInternalRouter';
-import cookies from 'js-cookie';
 import Cookies from 'js-cookie';
 
 type UserContextType = {
@@ -30,7 +28,6 @@ export const UserContext = createContext<UserContextType>({
 type Props = PropsWithChildren;
 
 const UserProvider = ({ children }: Props) => {
-  const { push } = useInternalRouter();
   const [userSession, setUserSession] = useState<InternalUserSession | null>(null);
 
   const saveUserSession = useCallback((newUserSession: InternalUserSession) => {
@@ -38,13 +35,13 @@ const UserProvider = ({ children }: Props) => {
       ...newUserSession,
     });
     localStorage.setItem(LOCAL_STORAGE_USER_KEY, JSON.stringify(newUserSession));
-    cookies.set(COOKIE_USER_KEY, newUserSession.accessToken);
+    Cookies.set(COOKIE_USER_KEY, newUserSession.accessToken);
   }, []);
 
   const clearUserSession = () => {
     setUserSession(null);
     localStorage.removeItem(LOCAL_STORAGE_USER_KEY);
-    cookies.remove(COOKIE_USER_KEY);
+    Cookies.remove(COOKIE_USER_KEY);
   };
 
   const updateBroadcastId = useCallback((broadcastId: string) => {

--- a/client/src/libs/actions.ts
+++ b/client/src/libs/actions.ts
@@ -179,3 +179,12 @@ export const getStreamInfo = async (): Promise<MyData> => {
 
   return result;
 };
+
+export const refreshAccessToken = async (): Promise<{ accessToken: string }> => {
+  const result = await fetcher<{ accessToken: string }>({
+    method: 'GET',
+    url: '/api/auth/refresh',
+  });
+
+  return result;
+};

--- a/client/src/libs/constants.ts
+++ b/client/src/libs/constants.ts
@@ -150,3 +150,7 @@ export const CONTENTS_CATEGORY = {
     NAME: '여행',
   } as const,
 };
+
+export const STATUS_CODE = {
+  UNAUTHORIZED: 401 as const,
+};

--- a/client/src/libs/fetcher.ts
+++ b/client/src/libs/fetcher.ts
@@ -1,5 +1,5 @@
 import type { FetcherParams } from '@libs/internalTypes';
-import { COOKIE_USER_KEY } from './constants';
+import { COOKIE_USER_KEY, STATUS_CODE } from './constants';
 import Cookies from 'js-cookie';
 
 const defaultHeaders = {
@@ -34,8 +34,7 @@ const fetcher = async <T>({ method, url, customOptions }: FetcherParams): Promis
   const response = await fetch(url, options);
 
   if (!response.ok) {
-    if (response.status === 401 && !url.startsWith('/api/auth')) {
-      // refresh token 패치 로직 추가하기
+    if (response.status === STATUS_CODE.UNAUTHORIZED && !url.startsWith('/api/auth')) {
       location.href = '/auth/refresh';
     } else {
       throw new Error('에러 아님');

--- a/client/src/libs/fetcher.ts
+++ b/client/src/libs/fetcher.ts
@@ -34,11 +34,12 @@ const fetcher = async <T>({ method, url, customOptions }: FetcherParams): Promis
   const response = await fetch(url, options);
 
   if (!response.ok) {
-    if (response.status === 401) {
+    if (response.status === 401 && !url.startsWith('/api/auth')) {
       // refresh token 패치 로직 추가하기
+      location.href = '/auth/refresh';
+    } else {
+      throw new Error('에러 아님');
     }
-
-    throw new Error('에러 아님');
   }
 
   const fetchResult = await response.json();

--- a/client/src/server/handlers.ts
+++ b/client/src/server/handlers.ts
@@ -71,6 +71,12 @@ const getMydata = () => {
   return HttpResponse.json(mockedMydata);
 };
 
+const refreshAccessToken = () => {
+  return HttpResponse.json({
+    accessToken: 'funch-access-access',
+  });
+};
+
 export const handlers = [
   http.get('/api/live/list', getLiveList),
   http.get('/api/live/follow', getFollowingList),
@@ -85,4 +91,5 @@ export const handlers = [
   http.post('/api/follow', makeFollow),
   http.delete('/api/follow', makeUnfollow),
   http.patch('/api/live/update', update),
+  http.get('/api/auth/refresh', refreshAccessToken),
 ];


### PR DESCRIPTION
## Issue

- [x] #317 


<br><br>

## Detail

- 엑세스토큰 재발급 액션 한 번만 호출하도록 변수 설정 
- unauthorized status code를 constants에 저장
- 401 에러 & /api/auth 호출 아님 -> /auth/refresh로 이동 -> /api/auth/refresh 호출 -> 토큰 리프레시 또는 로그아웃