### PR TITLE
홈 라이브 리스트 클라이언트 컴포넌트로 리팩토링 및 tanstack-query + suspense 적용, 서랍 일부 UI 개선

### DIFF
--- a/client/src/app/(domain)/features/RecommendedLives.tsx
+++ b/client/src/app/(domain)/features/RecommendedLives.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import clsx from 'clsx';
 import RecommendedLivesRenderer from './RecommendedLivesRenderer';
-import { Suspense } from 'react';
 import ErrorBoundary from '@components/ErrorBoundary';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getLiveList } from '@libs/actions';
@@ -10,18 +8,9 @@ import { TANSTACK_QUERY_KEY } from '@libs/constants';
 
 const RecommendedLives = () => {
   return (
-    <div>
-      <div className={clsx('mb-4 flex items-center justify-between')}>
-        <h2 className={clsx('text-content-neutral-primary funch-bold20')}>이 방송 어때요?</h2>
-      </div>
-      <ErrorBoundary
-        fallback={<p className="funch-bold16 text-content-neutral-strong">추천 목록을 불러올 수 없어요.</p>}
-      >
-        <Suspense fallback={<p className="funch-bold16 text-content-neutral-strong">추천 목록을 불러오고 있어요.</p>}>
-          <RecommendedLivesFetcher />
-        </Suspense>
-      </ErrorBoundary>
-    </div>
+    <ErrorBoundary fallback={<p className="funch-bold16 text-content-neutral-strong">추천 목록을 불러올 수 없어요.</p>}>
+      <RecommendedLivesFetcher />
+    </ErrorBoundary>
   );
 };
 
@@ -29,7 +18,7 @@ const RecommendedLivesFetcher = () => {
   const { data: lives } = useSuspenseQuery({
     queryKey: [TANSTACK_QUERY_KEY.LIVE_LIST],
     queryFn: async () => await getLiveList(),
-    refetchOnMount: true,
+    staleTime: 1000 * 60,
   });
 
   return <RecommendedLivesRenderer lives={lives} />;

--- a/client/src/app/(domain)/features/RecommendedLives.tsx
+++ b/client/src/app/(domain)/features/RecommendedLives.tsx
@@ -1,26 +1,14 @@
+'use client';
+
 import clsx from 'clsx';
-import { mockedBroadcasts } from '@mocks/broadcasts';
 import RecommendedLivesRenderer from './RecommendedLivesRenderer';
 import { Suspense } from 'react';
 import ErrorBoundary from '@components/ErrorBoundary';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getLiveList } from '@libs/actions';
+import { TANSTACK_QUERY_KEY } from '@libs/constants';
 
-const fetchData = async () => {
-  if (process.env.NODE_ENV !== 'production') return mockedBroadcasts;
-
-  const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-  const response = await fetch(`${apiUrl}/live/list`);
-
-  if (!response.ok) {
-    throw new Error('라이브 목록을 불러오는데 실패했어요.');
-  }
-
-  const data = await response.json();
-
-  return data;
-};
-
-const RecommendedLives = async () => {
+const RecommendedLives = () => {
   return (
     <div>
       <div className={clsx('mb-4 flex items-center justify-between')}>
@@ -37,8 +25,12 @@ const RecommendedLives = async () => {
   );
 };
 
-const RecommendedLivesFetcher = async () => {
-  const lives = await fetchData();
+const RecommendedLivesFetcher = () => {
+  const { data: lives } = useSuspenseQuery({
+    queryKey: [TANSTACK_QUERY_KEY.LIVE_LIST],
+    queryFn: async () => await getLiveList(),
+    refetchOnMount: true,
+  });
 
   return <RecommendedLivesRenderer lives={lives} />;
 };

--- a/client/src/app/(domain)/features/live/LiveInfo.tsx
+++ b/client/src/app/(domain)/features/live/LiveInfo.tsx
@@ -54,9 +54,14 @@ const LiveInfoWrapper = ({ children }: Props) => {
 
   return (
     <div
-      className={clsx('px-7 pb-6 pt-4', {
-        'absolute h-0 w-0 overflow-hidden': !isLivePage,
-      })}
+      className={clsx(
+        {
+          'absolute h-0 w-0 overflow-hidden p-0': !isLivePage,
+        },
+        {
+          'px-7 pb-6 pt-4': isLivePage,
+        },
+      )}
     >
       {children({ liveInfo })}
     </div>

--- a/client/src/app/(domain)/page.tsx
+++ b/client/src/app/(domain)/page.tsx
@@ -1,11 +1,20 @@
 import RecommendedLives from './features/RecommendedLives';
 import FollowingLives from './features/FollowingLives';
+import clsx from 'clsx';
+import { Suspense } from 'react';
 
 const HomePage = () => {
   return (
     <section className="min-h-home w-full px-7">
       <FollowingLives />
-      <RecommendedLives />
+      <div>
+        <div className={clsx('mb-4 flex items-center justify-between')}>
+          <h2 className={clsx('text-content-neutral-primary funch-bold20')}>이 방송 어때요?</h2>
+        </div>
+        <Suspense fallback={<p className="funch-bold16 text-content-neutral-strong">추천 목록을 불러오고 있어요.</p>}>
+          <RecommendedLives />
+        </Suspense>
+      </div>
     </section>
   );
 };

--- a/client/src/app/TanstackInitializer.tsx
+++ b/client/src/app/TanstackInitializer.tsx
@@ -6,7 +6,7 @@ import { type PropsWithChildren } from 'react';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5,
+      staleTime: 1000 * 60 * 3,
       retry: 1,
       refetchOnMount: false,
       refetchOnWindowFocus: false,

--- a/client/src/app/components/cabinet/CabinetItemList.tsx
+++ b/client/src/app/components/cabinet/CabinetItemList.tsx
@@ -1,8 +1,6 @@
 import { Broadcast } from '@libs/internalTypes';
-import { getSuggestedLiveList } from '@libs/actions';
 import Image from 'next/image';
-
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { comma } from '@libs/formats';
 
@@ -94,7 +92,7 @@ const CabinetListItem = ({ item, isDesktop }: { item: Broadcast; isDesktop: bool
                 <section className="flex w-full pl-[10px]">
                   <section className="flex w-2/3 flex-1 flex-col">
                     <div className="text-surface-neutral-inverse funch-bold14">{item.userName}</div>
-                    <div className="funch-bold10">{item.contentCategory}</div>
+                    <div className="funch-bold10 text-content-neutral-strong">{item.contentCategory}</div>
                   </section>
                   <p className="text-content-red-strong funch-bold12 flex items-center pr-2">
                     {'· ' + comma(item.viewerCount)}

--- a/client/src/app/components/cabinet/DesktopHeader.tsx
+++ b/client/src/app/components/cabinet/DesktopHeader.tsx
@@ -3,10 +3,8 @@
 import RefreshSvg from '@components/svgs/RefreshSvg';
 import DownArrowSvg from '@components/svgs/DownArrowSvg';
 import UpArrowSvg from '@components/svgs/UpArrowSvg';
-
 import clsx from 'clsx';
 import { useState } from 'react';
-import Button from '@components/Button';
 
 const COMPONENT_TYPE = {
   FOLLOW: 'FOLLOW' as const,
@@ -33,11 +31,17 @@ const DesktopHeader = ({ isExpanded, setIsExpanded, componentType }: ExpandedPro
       <h2 className="funch-bold14 funch-desktop:funch-bold16">
         {componentType === COMPONENT_TYPE.SUGGEST ? '추천 채널' : '팔로우 채널'}
       </h2>
-      <div className="flex">
+      <div className="flex gap-0.5">
         <button
           aria-label={componentType === COMPONENT_TYPE.SUGGEST ? '추천 채널 새로고침' : '팔로우 채널 새로고침'}
           title="새로고침"
-          className={`transform ${rotationCount > 0 ? 'rotate-360' : ''} transition duration-1000 ease-in-out`}
+          className={clsx(
+            'flex h-7 w-7 items-center justify-center',
+            `transform transition duration-1000 ease-in-out`,
+            {
+              'rotate-360': rotationCount > 0,
+            },
+          )}
           style={{
             transform: `rotate(${360 * rotationCount}deg)`,
           }}
@@ -64,11 +68,21 @@ const ArrowButton = ({ componentType, setIsExpanded }: ArrowButtonProps) => {
   return (
     <>
       {componentType === 'UP' ? (
-        <button aria-label="팔로우 채널 접기" title="접기" onClick={() => setIsExpanded((prev) => !prev)}>
+        <button
+          className="flex h-7 w-7 items-center justify-center"
+          aria-label="팔로우 채널 접기"
+          title="접기"
+          onClick={() => setIsExpanded((prev) => !prev)}
+        >
           <UpArrowSvg />
         </button>
       ) : (
-        <button aria-label="팔로우 채널 펼치기" title="펼치기" onClick={() => setIsExpanded((prev) => !prev)}>
+        <button
+          className="flex h-7 w-7 items-center justify-center"
+          aria-label="팔로우 채널 펼치기"
+          title="펼치기"
+          onClick={() => setIsExpanded((prev) => !prev)}
+        >
           <DownArrowSvg />
         </button>
       )}

--- a/client/src/app/components/layout/SearchView.tsx
+++ b/client/src/app/components/layout/SearchView.tsx
@@ -3,7 +3,13 @@
 import DeleteSvg from '@components/svgs/DeleteSvg';
 import ReadingGlassSvg from '@components/svgs/ReadingGlassSvg';
 import clsx from 'clsx';
-import { FormHTMLAttributes, ForwardedRef, forwardRef, type AllHTMLAttributes, type PropsWithChildren } from 'react';
+import {
+  type FormHTMLAttributes,
+  type ForwardedRef,
+  type AllHTMLAttributes,
+  type PropsWithChildren,
+  forwardRef,
+} from 'react';
 
 type SearchWrapperProps = FormHTMLAttributes<HTMLFormElement> & PropsWithChildren;
 

--- a/client/src/libs/actions.ts
+++ b/client/src/libs/actions.ts
@@ -16,7 +16,6 @@ export const getLiveList = async (): Promise<Broadcast[]> => {
     method: 'GET',
     url: '/api/live/list',
   });
-
   return result.sort((a, b) => b.viewerCount - a.viewerCount);
 };
 

--- a/client/src/libs/constants.ts
+++ b/client/src/libs/constants.ts
@@ -3,6 +3,10 @@ export const APP_THEME = {
   DARK: 'DARK' as const,
 };
 
+export const TANSTACK_QUERY_KEY = {
+  LIVE_LIST: 'LIVE_LIST' as const,
+};
+
 export const LOCAL_STORAGE_THEME_KEY = 'theme';
 export const LOCAL_STORAGE_USER_KEY = 'funch-user';
 export const LOCAL_STORAGE_PREV_SEARCHES_KEY = 'funch-prev-searches';


### PR DESCRIPTION
## Issues

- [x] #321

<br><br>

## Detail

- 서랍의 리프레시 버튼, 펴기//접기 버튼 크기를 w-7, h-7으로 조정 (라이트하우스 권고)
- 서랍 일부 UI 텍스트 색상 개선 (라이트하우스 권고)
- RecommendedLives를 클라이언트 컴포넌트로 리팩토링
