### PR TITLE
채팅 번역 기능 추가

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,9 +21,14 @@ jobs:
             cd /root/web25-funch
             git switch main
             git pull origin main
-            cd client
+            cd /root/web25-funch/client
+            npm install
             npm run build
-            cd ..
+            cd /root/web25-funch/chatServer
+            npm install
+            cd /root/web25-funch/applicationServer
+            npm install
+            cd /root/web25-funch
             sh deploy.sh
           EOF
 
@@ -43,5 +48,6 @@ jobs:
             git switch main
             git pull origin main
             cd mediaServer
+            npm install
             sh deploy.sh
           EOF

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,6 +21,9 @@ jobs:
             cd /root/web25-funch
             git switch main
             git pull origin main
+            cd client
+            npm run build
+            cd ..
             sh deploy.sh
           EOF
 

--- a/chatServer/main.ts
+++ b/chatServer/main.ts
@@ -2,6 +2,7 @@ import { Server } from 'socket.io';
 import validate from 'utf-8-validate';
 import EventEmitter from 'events';
 import { Name } from './utils/name';
+import { translate } from './utils/translation';
 
 const PORT = Number(process.env.PORT) || 7990;
 const io = new Server(PORT, {
@@ -38,11 +39,14 @@ io.on('connection', (socket) => {
   };
   eventEmitter.on(broadcastId, chatEvent);
 
-  socket.on('chat', (data: Buffer) => {
+  socket.on('chat', async (data: Buffer) => {
     try {
       const isValidUtf8 = validate(data);
       const chatData = JSON.parse(data.toString('utf8'));
-      if (isValidUtf8) eventEmitter.emit(broadcastId, chatData);
+      if (isValidUtf8) {
+        chatData.content = await translate(chatData.content, chatData.translation);
+        eventEmitter.emit(broadcastId, chatData);
+      }
     } catch (e) {
       console.log(e);
     }

--- a/chatServer/utils/translation.ts
+++ b/chatServer/utils/translation.ts
@@ -1,0 +1,71 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+const CLOVA_ENDPOINT = 'https://clovastudio.stream.ntruss.com/testapp/v1/chat-completions/HCX-003';
+
+const translationMap = new Map([
+  ['korean', '한국어'],
+  ['english', '영어'],
+  ['japanese', '일본어'],
+  ['chinese', '중국어'],
+]);
+
+function fetchTranslate(text) {
+  const prompt = {
+    messages: [
+      {
+        role: 'system',
+        content: '- 주어진 주제를 한국어, 영어, 일본어, 중국어로 생성합니다.\n',
+      },
+      {
+        role: 'user',
+        content: text,
+      },
+    ],
+    topP: 0.8,
+    topK: 0,
+    maxTokens: 512,
+    temperature: 0.3,
+    repeatPenalty: 3.0,
+    stopBefore: [],
+    includeAiFilters: true,
+    seed: 0,
+  };
+
+  return fetch(CLOVA_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+      'X-NCP-CLOVASTUDIO-API-KEY': process.env.X_NCP_CLOVASTUDIO_API_KEY,
+      'X-NCP-APIGW-API-KEY': process.env.X_NCP_APIGW_API_KEY,
+      'X-NCP-CLOVASTUDIO-REQUEST-ID': process.env.X_NCP_CLOVASTUDIO_REQUEST_ID,
+    },
+    body: JSON.stringify(prompt),
+  });
+}
+
+async function translate(text, lang?) {
+  if (!lang || lang === 'null') return text;
+
+  const response = await (await fetchTranslate(text)).text();
+  const results = response.trim().split('\n\n');
+
+  for (let idx = results.length - 1; idx >= 0; idx--) {
+    if (results[idx].match(/event:result/)) {
+      const result = results[idx].match(/data:(.+)/);
+      const data = JSON.parse(result[1]);
+      const translates = data.message.content.split('\n').reduce((obj, cur) => {
+        const [key, value] = cur.split(':');
+        obj[key.trim()] = value.trim();
+        return obj;
+      }, {});
+
+      return translates[translationMap.get(lang)];
+    }
+  }
+
+  return text;
+}
+
+export { translate };

--- a/mediaServer/core/media/ffmpeg.ts
+++ b/mediaServer/core/media/ffmpeg.ts
@@ -11,11 +11,12 @@ ffmpeg.setFfprobePath(ffprobePath.path);
 const defaultOutputOptions = [
   '-map 0:v',
   '-map 0:a',
-  '-hls_time 2',
+  '-hls_time 1',
   '-hls_list_size 3',
   '-hls_segment_type fmp4',
   '-hls_flags split_by_time+independent_segments+omit_endlist',
   '-preset ultrafast',
+  '-threads 2',
 ];
 
 function initializeFFMpeg(ffmpegInputStream: PassThrough, storagePath: string) {


### PR DESCRIPTION
## Issue

- [x] #328 
- [x] #329  


<br><br>

## Detail

- Github Actions의 Deployment workflow의 funch server deploy 스크립트에
client를 build한 이후 하위 디렉토리에 npm install을 수행해 의존성을 갱신하도록 변경하였습니다. 반영하도록 변경하였습니다.

- 클러스터링 도입을 테스트한 이후 특별한 효과를 보지 못해 FFMpeg의 Output
Options에 -threads 2 명시적으로 추가해주는 것으로 마무리 했습니다.

- Clova Studio API를 활용해 필요하다면 번역을 수행하는 기능을 채팅 서버에 포함했습니다.

